### PR TITLE
Fixing issue of shortcode_exists function in wordpress 3.3

### DIFF
--- a/easy-property-listings.php
+++ b/easy-property-listings.php
@@ -156,6 +156,9 @@ if ( ! class_exists( 'Easy_Property_Listings' ) ) :
 		 * @return void
 		 */
 		private function includes() {
+			
+			// Wordpress core functions for keeping compatibility.
+			require_once EPL_COMPATABILITY . 'wp-functions-compat.php';
 		
 			global $epl_settings;
 			

--- a/lib/compatibility/wp-functions-compat.php
+++ b/lib/compatibility/wp-functions-compat.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Wordpress core functions for keeping compatibility.
+ *
+ * @since 2.1.11
+ */
+
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+if ( ! function_exists( 'shortcode_exists' ) ) {
+	/**
+	 * Whether a registered shortcode exists named $tag
+	 *
+	 * @since 2.1.11
+	 *
+	 * @global array $shortcode_tags List of shortcode tags and their callback hooks.
+	 *
+	 * @param string $tag Shortcode tag to check.
+	 * @return bool Whether the given shortcode exists.
+	 */
+	function shortcode_exists( $tag ) {
+		global $shortcode_tags;
+		return array_key_exists( $tag, $shortcode_tags );
+	}
+}


### PR DESCRIPTION
There was an error with `shortcode_exists()` function in Wordpress 3.3 and this pull request fixes that issue.
Function `shortcode_exists()` used in `lib/assets/assets.php` on `line 51` that cause this issue in Wordpress 3.3

For keeping compatibility between Wordpress versions a new file added to compatibility folder.