### PR TITLE
Easy Property Listings 2.2.5 maintenance release

### DIFF
--- a/easy-property-listings.php
+++ b/easy-property-listings.php
@@ -5,7 +5,7 @@
  * Description:  Fast. Flexible. Forward-thinking solution for real estate agents using WordPress. Easy Property Listing is one of the most dynamic and feature rich Real Estate plugin for WordPress available on the market today. Built for scale, lead generation and works with any theme!
  * Author: Merv Barrett
  * Author URI: http://www.realestateconnected.com.au
- * Version: 2.2.4
+ * Version: 2.2.5
  * Text Domain: epl
  * Domain Path: languages
  *
@@ -25,7 +25,7 @@
  * @package EPL
  * @category Core
  * @author Merv Barrett
- * @version 2.2.4
+ * @version 2.2.5
  */
  
 // Exit if accessed directly
@@ -83,7 +83,7 @@ if ( ! class_exists( 'Easy_Property_Listings' ) ) :
 		public function setup_constants() {		
 			// Plugin version
 			if ( ! defined( 'EPL_PROPERTY_VER' ) ) {
-				define( 'EPL_PROPERTY_VER', '2.2.4' );
+				define( 'EPL_PROPERTY_VER', '2.2.5' );
 			}
 			// Plugin DB version
 			if ( ! defined( 'EPL_PROPERTY_DB_VER' ) ) {
@@ -149,7 +149,7 @@ if ( ! class_exists( 'Easy_Property_Listings' ) ) :
 		 */
 		private function includes() {
 			
-			// Wordpress core functions for keeping compatibility.
+			// WordPress core functions for keeping compatibility.
 			require_once EPL_COMPATABILITY . 'wp-functions-compat.php';
 		
 			global $epl_settings;

--- a/lib/includes/plugins.php
+++ b/lib/includes/plugins.php
@@ -28,7 +28,7 @@ if( !is_admin() ) {
  * @return array $links
  */
 function epl_plugin_action_links( $links, $file ) {
-	$settings_link = '<a href="' . admin_url( 'admin.php?page=epl-general' ) . '">' . esc_html__( 'General Settings', 'epl' ) . '</a>';
+	$settings_link = '<a href="' . admin_url( 'admin.php?page=epl-settings' ) . '">' . esc_html__( 'General Settings', 'epl' ) . '</a>';
 	if ( $file == 'easy-property-listings/easy-property-listings.php' )
 		array_unshift( $links, $settings_link );
 
@@ -52,7 +52,7 @@ function epl_plugin_row_meta( $input, $file ) {
 
 	$links = array(
 		'<a href="' . admin_url( 'index.php?page=epl-getting-started' ) . '">' . esc_html__( 'Getting Started', 'epl' ) . '</a>',
-		'<a href="http://www.easypropertylistings.com.au/extensions/">' . esc_html__( 'Add Ons', 'epl' ) . '</a>',
+		'<a href="http://www.easypropertylistings.com.au/extensions/?utm_source=plugins-page&utm_medium=plugin-row&utm_campaign=admin">' . esc_html__( 'Add Ons', 'epl' ) . '</a>',
 	);
 
 	$input = array_merge( $input, $links );

--- a/lib/languages/epl.pot
+++ b/lib/languages/epl.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the Easy Property Listings package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Easy Property Listings 2.2.4\n"
+"Project-Id-Version: Easy Property Listings 2.2.5\n"
 "Report-Msgid-Bugs-To: http://wordpress.org/support/plugin/easy-property-listings\n"
-"POT-Creation-Date: 2015-08-05 16:37+0800\n"
-"PO-Revision-Date: 2015-08-05 16:37+0800\n"
+"POT-Creation-Date: 2015-08-20 00:16+0800\n"
+"PO-Revision-Date: 2015-08-20 00:16+0800\n"
 "Last-Translator: Merv Barrett <admin@realestateconnected.com.au>\n"
 "Language-Team: Real Estate Connected <admin@realestateconnected.com.au>\n"
 "Language: en\n"
@@ -505,46 +505,46 @@ msgstr ""
 msgid " Car Spaces"
 msgstr ""
 
-#: includes/functions.php:137 menus/menu-welcome.php:802
+#: includes/functions.php:137 menus/menu-welcome.php:807
 msgid "Property (Residential)"
 msgstr ""
 
 #: includes/functions.php:138 includes/functions.php:1146 includes/functions.php:1148
-#: includes/install.php:66 menus/menu-welcome.php:804 post-types/post-type-land.php:28
+#: includes/install.php:66 menus/menu-welcome.php:809 post-types/post-type-land.php:28
 #: post-types/post-type-land.php:29 post-types/post-type-land.php:30
 #: updates/epl-1.3.1.php:5 widgets/widget-admin-dashboard.php:56
 msgid "Land"
 msgstr ""
 
 #: includes/functions.php:139 includes/functions.php:1152 includes/functions.php:1154
-#: menus/menu-welcome.php:803 post-types/post-type-rental.php:29
+#: menus/menu-welcome.php:808 post-types/post-type-rental.php:29
 #: updates/epl-1.3.1.php:6 widgets/widget-admin-dashboard.php:59
 msgid "Rental"
 msgstr ""
 
 #: includes/functions.php:140 includes/functions.php:1158 includes/functions.php:1160
-#: includes/install.php:68 menus/menu-welcome.php:805 post-types/post-type-rural.php:28
+#: includes/install.php:68 menus/menu-welcome.php:810 post-types/post-type-rural.php:28
 #: post-types/post-type-rural.php:29 post-types/post-type-rural.php:30
 #: updates/epl-1.3.1.php:7 widgets/widget-admin-dashboard.php:62
 msgid "Rural"
 msgstr ""
 
 #: includes/functions.php:141 includes/functions.php:444 includes/functions.php:1164
-#: includes/functions.php:1166 includes/install.php:70 menus/menu-welcome.php:806
+#: includes/functions.php:1166 includes/install.php:70 menus/menu-welcome.php:811
 #: post-types/post-type-commercial.php:29 updates/epl-1.3.1.php:9
 #: widgets/widget-admin-dashboard.php:65
 msgid "Commercial"
 msgstr ""
 
 #: includes/functions.php:142 includes/functions.php:1170 includes/functions.php:1172
-#: includes/install.php:71 menus/menu-welcome.php:807
+#: includes/install.php:71 menus/menu-welcome.php:812
 #: post-types/post-type-commercial_land.php:30 updates/epl-1.3.1.php:10
 #: widgets/widget-admin-dashboard.php:68
 msgid "Commercial Land"
 msgstr ""
 
 #: includes/functions.php:143 includes/functions.php:1176 includes/functions.php:1178
-#: includes/install.php:69 menus/menu-welcome.php:808
+#: includes/install.php:69 menus/menu-welcome.php:813
 #: post-types/post-type-business.php:30 updates/epl-1.3.1.php:8
 #: widgets/widget-admin-dashboard.php:71
 msgid "Business"
@@ -1148,7 +1148,7 @@ msgid ""
 "grid options."
 msgstr ""
 
-#: includes/functions.php:1250 menus/menu-welcome.php:928
+#: includes/functions.php:1250 menus/menu-welcome.php:933
 msgid "Theme Compatibility"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "What's New"
 msgstr ""
 
-#: menus/menu-help.php:36 menus/menu-welcome.php:269 menus/menu-welcome.php:782
+#: menus/menu-help.php:36 menus/menu-welcome.php:269 menus/menu-welcome.php:787
 msgid "Full Change Log"
 msgstr ""
 
@@ -1519,7 +1519,7 @@ msgstr ""
 msgid "Support the project"
 msgstr ""
 
-#: menus/menu-help.php:39 menus/menu-welcome.php:783
+#: menus/menu-help.php:39 menus/menu-welcome.php:788
 msgid "Visit Support"
 msgstr ""
 
@@ -1577,7 +1577,7 @@ msgstr ""
 msgid "The video will show you how to add a listing quickly and easily."
 msgstr ""
 
-#: menus/menu-help.php:112 menus/menu-welcome.php:855 widgets/widget-functions.php:12
+#: menus/menu-help.php:112 menus/menu-welcome.php:860 widgets/widget-functions.php:12
 #: widgets/widget-listing.php:270
 msgid "Title"
 msgstr ""
@@ -1621,7 +1621,7 @@ msgstr ""
 msgid "Listing Image Gallery"
 msgstr ""
 
-#: menus/menu-help.php:134 menus/menu-welcome.php:876
+#: menus/menu-help.php:134 menus/menu-welcome.php:881
 msgid "Add a gallery of images to your listings with the WordPress Add Media button."
 msgstr ""
 
@@ -1631,7 +1631,7 @@ msgid ""
 "media upload box once the images are attached to the listing."
 msgstr ""
 
-#: menus/menu-help.php:147 menus/menu-welcome.php:894 meta-boxes/meta-boxes.php:109
+#: menus/menu-help.php:147 menus/menu-welcome.php:899 meta-boxes/meta-boxes.php:109
 #: post-types/post-type-business.php:86 post-types/post-type-commercial.php:84
 #: post-types/post-type-commercial_land.php:85 post-types/post-type-land.php:85
 #: post-types/post-type-property.php:85 post-types/post-type-rental.php:84
@@ -1639,26 +1639,26 @@ msgstr ""
 msgid "Listing Details"
 msgstr ""
 
-#: menus/menu-help.php:149 menus/menu-welcome.php:900 meta-boxes/meta-boxes.php:121
+#: menus/menu-help.php:149 menus/menu-welcome.php:905 meta-boxes/meta-boxes.php:121
 msgid "Heading"
 msgstr ""
 
-#: menus/menu-help.php:150 menus/menu-welcome.php:901
+#: menus/menu-help.php:150 menus/menu-welcome.php:906
 msgid "Enter the descriptive listing headline like \"Great Property with Views\"."
 msgstr ""
 
-#: menus/menu-help.php:152 menus/menu-welcome.php:903 meta-boxes/meta-boxes.php:149
+#: menus/menu-help.php:152 menus/menu-welcome.php:908 meta-boxes/meta-boxes.php:149
 #: post-types/post-types.php:77
 msgid "Second Listing Agent"
 msgstr ""
 
-#: menus/menu-help.php:153 menus/menu-welcome.php:904
+#: menus/menu-help.php:153 menus/menu-welcome.php:909
 msgid ""
 "If the listing has two real estate agents marketing it, enter their WordPress user "
 "name here. The primary agent is the post Author."
 msgstr ""
 
-#: menus/menu-help.php:155 menus/menu-welcome.php:906
+#: menus/menu-help.php:155 menus/menu-welcome.php:911
 msgid "Inspection Times"
 msgstr ""
 
@@ -1709,19 +1709,19 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: menus/menu-welcome.php:157 menus/menu-welcome.php:756 menus/menu-welcome.php:1092
+#: menus/menu-welcome.php:157 menus/menu-welcome.php:761 menus/menu-welcome.php:1097
 #, php-format
 msgid "Welcome to Easy Property Listings %s"
 msgstr ""
 
-#: menus/menu-welcome.php:158 menus/menu-welcome.php:757 menus/menu-welcome.php:1093
+#: menus/menu-welcome.php:158 menus/menu-welcome.php:762 menus/menu-welcome.php:1098
 #, php-format
 msgid ""
 "Thank you for updating to the latest version! Easy Property Listings %s is ready to "
 "make your real estate website faster, safer and better!"
 msgstr ""
 
-#: menus/menu-welcome.php:159 menus/menu-welcome.php:758 menus/menu-welcome.php:1094
+#: menus/menu-welcome.php:159 menus/menu-welcome.php:763 menus/menu-welcome.php:1099
 #, php-format
 msgid "Version %s"
 msgstr ""
@@ -1933,499 +1933,507 @@ msgid ""
 msgstr ""
 
 #: menus/menu-welcome.php:273
-msgid "Version 2.2.4"
+msgid "Version 2.2.5"
 msgstr ""
 
 #: menus/menu-welcome.php:275
+msgid "Fix: Widget construct fixes for WordPress 4.3."
+msgstr ""
+
+#: menus/menu-welcome.php:278
+msgid "Version 2.2.4"
+msgstr ""
+
+#: menus/menu-welcome.php:280
 msgid ""
 "Tweak: Improvements to Commercial/Commercial Land/Business pricing when set to Lease "
 "type to display free form price text."
 msgstr ""
 
-#: menus/menu-welcome.php:276
+#: menus/menu-welcome.php:281
 msgid "Tweak: Bar graph in dashboard will no longer cover address if set to low."
 msgstr ""
 
-#: menus/menu-welcome.php:277
+#: menus/menu-welcome.php:282
 msgid "Tweak: Added sticker CSS styling for single listing."
 msgstr ""
 
-#: menus/menu-welcome.php:278
+#: menus/menu-welcome.php:283
 msgid "Fix: Search Widget/Shortcode display house category value instead of key."
 msgstr ""
 
-#: menus/menu-welcome.php:279
+#: menus/menu-welcome.php:284
 msgid "Fix: Search Widget/Shortcode Property ID correctly searches numeric listing ID."
 msgstr ""
 
-#: menus/menu-welcome.php:280
+#: menus/menu-welcome.php:285
 msgid ""
 "Fix: Search Widget/Shortcode excluded non searchable fields from land, commercial, "
 "commercial land and business post types."
 msgstr ""
 
-#: menus/menu-welcome.php:283
+#: menus/menu-welcome.php:288
 msgid "Version 2.2.3"
 msgstr ""
 
-#: menus/menu-welcome.php:285
+#: menus/menu-welcome.php:290
 msgid "Tweak: Adjusted new sorter function to work on lower than PHP version 5.3."
 msgstr ""
 
-#: menus/menu-welcome.php:286
+#: menus/menu-welcome.php:291
 msgid ""
 "Tweak: Moved old template functions to theme compatibility, will be removed in future "
 "version."
 msgstr ""
 
-#: menus/menu-welcome.php:287
+#: menus/menu-welcome.php:292
 msgid ""
 "Tweak: Set sorter list style to none to prevent some themes from displaying a list "
 "bullet."
 msgstr ""
 
-#: menus/menu-welcome.php:290
+#: menus/menu-welcome.php:295
 msgid "Version 2.2.2"
 msgstr ""
 
-#: menus/menu-welcome.php:292
+#: menus/menu-welcome.php:297
 msgid "Tweak: CSS tweak for image size to retain proportion on some themes."
 msgstr ""
 
-#: menus/menu-welcome.php:293
+#: menus/menu-welcome.php:298
 msgid ""
 "Tweak: Adjusted position of show/hide suburb on Commercial/Business listing types."
 msgstr ""
 
-#: menus/menu-welcome.php:294
+#: menus/menu-welcome.php:299
 msgid "Fix: Archive image correctly loading 300x200 image."
 msgstr ""
 
-#: menus/menu-welcome.php:295
+#: menus/menu-welcome.php:300
 msgid "Fix: Listing address display settings fixed."
 msgstr ""
 
-#: menus/menu-welcome.php:298
+#: menus/menu-welcome.php:303
 msgid "Version 2.2.1"
 msgstr ""
 
-#: menus/menu-welcome.php:300
+#: menus/menu-welcome.php:305
 msgid "Tweak: Set padding for search tabs for better display on some themes."
 msgstr ""
 
-#: menus/menu-welcome.php:301
+#: menus/menu-welcome.php:306
 msgid "Fix: Search function fix checking for empty option when using custom filters."
 msgstr ""
 
-#: menus/menu-welcome.php:304
+#: menus/menu-welcome.php:309
 msgid "Version 2.2"
 msgstr ""
 
-#: menus/menu-welcome.php:306
+#: menus/menu-welcome.php:311
 msgid ""
 "New: Search shortcode and widget rebuilt to enable adding additional fields through "
 "filters and hooks."
 msgstr ""
 
-#: menus/menu-welcome.php:307
+#: menus/menu-welcome.php:312
 msgid ""
 "New: Search shortcode and widget added additional search fields for City, State, "
 "Postcode and Country."
 msgstr ""
 
-#: menus/menu-welcome.php:308
+#: menus/menu-welcome.php:313
 msgid ""
 "New: Search shortcode and widget allows for optional multi select of house category."
 msgstr ""
 
-#: menus/menu-welcome.php:309
+#: menus/menu-welcome.php:314
 msgid "New: Search shortcode and widget improved responsive CSS."
 msgstr ""
 
-#: menus/menu-welcome.php:310
+#: menus/menu-welcome.php:315
 msgid "New: Grid styles included in main CSS for use in extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:311
+#: menus/menu-welcome.php:316
 msgid ""
 "New: Upload button added for use in custom plug-ins and extensions to upload files."
 msgstr ""
 
-#: menus/menu-welcome.php:312
+#: menus/menu-welcome.php:317
 msgid "New: Filter to adjust tour labels."
 msgstr ""
 
-#: menus/menu-welcome.php:313
+#: menus/menu-welcome.php:318
 msgid "New: Filters to adjust Floor Plan labels."
 msgstr ""
 
-#: menus/menu-welcome.php:314
+#: menus/menu-welcome.php:319
 msgid "New: Filters to adjust External Link labels."
 msgstr ""
 
-#: menus/menu-welcome.php:315
+#: menus/menu-welcome.php:320
 msgid "New: Sold prices now display when set on front end and manage listings pages."
 msgstr ""
 
-#: menus/menu-welcome.php:316
+#: menus/menu-welcome.php:321
 msgid "New: Label function for returning meta labels."
 msgstr ""
 
-#: menus/menu-welcome.php:317
+#: menus/menu-welcome.php:322
 msgid ""
 "New: Ads on settings no longer display when there is an activated extension present."
 msgstr ""
 
-#: menus/menu-welcome.php:318
+#: menus/menu-welcome.php:323
 msgid "New: Locked and help cases options for use in extensions and custom plugins."
 msgstr ""
 
-#: menus/menu-welcome.php:319
+#: menus/menu-welcome.php:324
 msgid ""
 "New: Theme compatibility mode which enables all themes to display correctly with "
 "options to disable featured images for themes that automatically add featured images."
 msgstr ""
 
-#: menus/menu-welcome.php:320
+#: menus/menu-welcome.php:325
 msgid ""
 "New: City setting to allow addresses in countries that need more than a suburb Label "
 "is customisable from settings."
 msgstr ""
 
-#: menus/menu-welcome.php:321
+#: menus/menu-welcome.php:326
 msgid "New: Country setting to allow the country to display with the listing address."
 msgstr ""
 
-#: menus/menu-welcome.php:322
+#: menus/menu-welcome.php:327
 msgid "New: Able to adjust or add more registered thumbnail sizes through a filter."
 msgstr ""
 
-#: menus/menu-welcome.php:323
+#: menus/menu-welcome.php:328
 msgid "New: Function to get all the values associated with a specific post meta key."
 msgstr ""
 
-#: menus/menu-welcome.php:324
+#: menus/menu-welcome.php:329
 msgid ""
 "New: Replaced the_post_thumbnail on archive pages and shortcodes with a customisable "
 "hook allowing for additional customisation with themes."
 msgstr ""
 
-#: menus/menu-welcome.php:325
+#: menus/menu-welcome.php:330
 msgid ""
 "New: Specific templates for theme compatibility mode for archive and single listings."
 msgstr ""
 
-#: menus/menu-welcome.php:326
+#: menus/menu-welcome.php:331
 msgid ""
 "New: Template loading system allowing for additional templates to be added to "
 "shortcodes and widgets from themes, custom plug-ins and extensions. This allows you "
 "to create an unlimited number of templates and load them from your theme."
 msgstr ""
 
-#: menus/menu-welcome.php:327
+#: menus/menu-welcome.php:332
 msgid "New: Sorter allows for sorting by current/sold leased."
 msgstr ""
 
-#: menus/menu-welcome.php:328
+#: menus/menu-welcome.php:333
 msgid "New: Ability to add additional sorter via filter."
 msgstr ""
 
-#: menus/menu-welcome.php:329
+#: menus/menu-welcome.php:334
 msgid "New: Post counter function for use in extensions and custom plug-ins."
 msgstr ""
 
-#: menus/menu-welcome.php:330
+#: menus/menu-welcome.php:335
 msgid "New: User fields re-built which allows for adding on new fields through filter."
 msgstr ""
 
-#: menus/menu-welcome.php:331
+#: menus/menu-welcome.php:336
 msgid "New: Help meta type allowing for better internal documentation in extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:332
+#: menus/menu-welcome.php:337
 msgid "New: City meta field added to all listing types when enabled."
 msgstr ""
 
-#: menus/menu-welcome.php:333
+#: menus/menu-welcome.php:338
 msgid "New: Rental display or hide rental price."
 msgstr ""
 
-#: menus/menu-welcome.php:334
+#: menus/menu-welcome.php:339
 msgid "New: Check-box single field type."
 msgstr ""
 
-#: menus/menu-welcome.php:335
+#: menus/menu-welcome.php:340
 msgid ""
 "New: Actions added to enable extensions to better hook into listings types and "
 "optimised functions for admin column details."
 msgstr ""
 
-#: menus/menu-welcome.php:336
+#: menus/menu-welcome.php:341
 msgid "New: Dashboard widget now displays other extensions content counts."
 msgstr ""
 
-#: menus/menu-welcome.php:337
+#: menus/menu-welcome.php:342
 msgid ""
 "New: Listing widget now allows for additional selectable templates to be added "
 "through custom plug-ins, hooks and themes."
 msgstr ""
 
-#: menus/menu-welcome.php:338
+#: menus/menu-welcome.php:343
 msgid "New: Replaced widget image with a dynamic action."
 msgstr ""
 
-#: menus/menu-welcome.php:339
+#: menus/menu-welcome.php:344
 msgid "New: Filter added for Gravatar image."
 msgstr ""
 
-#: menus/menu-welcome.php:340
+#: menus/menu-welcome.php:345
 msgid "New: Replaced widget and author box image functions with actions."
 msgstr ""
 
-#: menus/menu-welcome.php:341
+#: menus/menu-welcome.php:346
 msgid "New: Uninstall function to remove all Easy Property Listings content."
 msgstr ""
 
-#: menus/menu-welcome.php:342
+#: menus/menu-welcome.php:347
 msgid "New: Get option function."
 msgstr ""
 
-#: menus/menu-welcome.php:343
+#: menus/menu-welcome.php:348
 msgid ""
 "New: When saving settings on extensions sub tabs you are no longer taken to the first "
 "tab."
 msgstr ""
 
-#: menus/menu-welcome.php:344
+#: menus/menu-welcome.php:349
 msgid "New: Customisable state label."
 msgstr ""
 
-#: menus/menu-welcome.php:345
+#: menus/menu-welcome.php:350
 msgid "Tweak: Improved under offer, sold and leased labels."
 msgstr ""
 
-#: menus/menu-welcome.php:346
+#: menus/menu-welcome.php:351
 msgid ""
 "Tweak: Improved install function to reduce code and allow for new settings to be "
 "added."
 msgstr ""
 
-#: menus/menu-welcome.php:347
+#: menus/menu-welcome.php:352
 msgid "Tweak: Removed redundant code and streamlined templates."
 msgstr ""
 
-#: menus/menu-welcome.php:348
+#: menus/menu-welcome.php:353
 msgid "Tweak: Improved reset query function."
 msgstr ""
 
-#: menus/menu-welcome.php:349
+#: menus/menu-welcome.php:354
 msgid "Tweak: Removed old functions improving plugin code."
 msgstr ""
 
-#: menus/menu-welcome.php:350
+#: menus/menu-welcome.php:355
 msgid "Tweak: Rebuilt address function to allow for city and country."
 msgstr ""
 
-#: menus/menu-welcome.php:351
+#: menus/menu-welcome.php:356
 msgid "Tweak: Improved sorter function in all shortcodes."
 msgstr ""
 
-#: menus/menu-welcome.php:352
+#: menus/menu-welcome.php:357
 msgid ""
 "Tweak: Improvements to Commercial and Business listing types to better comply with "
 "REAXML format with business takings, franchise, terms and commercial outgoings."
 msgstr ""
 
-#: menus/menu-welcome.php:353
+#: menus/menu-welcome.php:358
 msgid "Tweak: Reorganised settings page."
 msgstr ""
 
-#: menus/menu-welcome.php:354
+#: menus/menu-welcome.php:359
 msgid "Tweak: Translations updated and additional tags added."
 msgstr ""
 
-#: menus/menu-welcome.php:355
+#: menus/menu-welcome.php:360
 msgid ""
 "Tweak: Search button default label changed from \"Find Me A Property!\" to \"Search\"."
 msgstr ""
 
-#: menus/menu-welcome.php:356
+#: menus/menu-welcome.php:361
 msgid "Tweak: Applied custom suburb label to EPL - Listing Widget."
 msgstr ""
 
-#: menus/menu-welcome.php:357
+#: menus/menu-welcome.php:362
 msgid "Fix: Listings house categories correctly display labels instead of values."
 msgstr ""
 
-#: menus/menu-welcome.php:358
+#: menus/menu-welcome.php:363
 msgid "Fix: Listings with carport, garage or values set to zero no longer display."
 msgstr ""
 
-#: menus/menu-welcome.php:359
+#: menus/menu-welcome.php:364
 msgid "Fix: Shortcode compatibility for WordPress 3.3 thanks to codewp"
 msgstr ""
 
-#: menus/menu-welcome.php:360
+#: menus/menu-welcome.php:365
 msgid "Fix: Saving listing when in debug mode and ticking hide map or hide author box."
 msgstr ""
 
-#: menus/menu-welcome.php:361
+#: menus/menu-welcome.php:366
 msgid "Fix: New Zealand currency now displays a dollar sign."
 msgstr ""
 
-#: menus/menu-welcome.php:364
+#: menus/menu-welcome.php:369
 msgid "Version 2.1.11"
 msgstr ""
 
-#: menus/menu-welcome.php:367
+#: menus/menu-welcome.php:372
 msgid ""
 "Tweak: Removed sub titles \"Property Manager\" and \"Real Estate Agent\" from the "
 "single listing template for better language support and to facilitate the hiding of "
 "the author box."
 msgstr ""
 
-#: menus/menu-welcome.php:368
+#: menus/menu-welcome.php:373
 msgid "Tweak: Added epl- prefix to all author-box and widget css."
 msgstr ""
 
-#: menus/menu-welcome.php:369
+#: menus/menu-welcome.php:374
 msgid ""
 "Tweak: Renamed author-box container with epl-author-box-container as it was harder to "
 "target the author box content and adjusted JS for tabs."
 msgstr ""
 
-#: menus/menu-welcome.php:370
+#: menus/menu-welcome.php:375
 msgid "Tweak: Improved author box responsive CSS."
 msgstr ""
 
-#: menus/menu-welcome.php:371
+#: menus/menu-welcome.php:376
 msgid "Tweak: Updated extension updater for multisite and other improvements."
 msgstr ""
 
-#: menus/menu-welcome.php:372
+#: menus/menu-welcome.php:377
 msgid "Tweak: Leased label when adding a property will use custom label."
 msgstr ""
 
-#: menus/menu-welcome.php:373
+#: menus/menu-welcome.php:378
 msgid "Tweak: Wrapper class for property category."
 msgstr ""
 
-#: menus/menu-welcome.php:374
+#: menus/menu-welcome.php:379
 msgid "Fix: Undefined status if importing listings not using current status."
 msgstr ""
 
-#: menus/menu-welcome.php:375
+#: menus/menu-welcome.php:380
 msgid ""
 "Fix: When user selects grid/list option and pages the user selected view is retained."
 msgstr ""
 
-#: menus/menu-welcome.php:376
+#: menus/menu-welcome.php:381
 msgid "Fix: [listing post_type=\"rental\"] shortcode price sorting for rental."
 msgstr ""
 
-#: menus/menu-welcome.php:377
+#: menus/menu-welcome.php:382
 msgid "New: Author box is now able to be hidden on a per listing basis."
 msgstr ""
 
-#: menus/menu-welcome.php:378
+#: menus/menu-welcome.php:383
 msgid "New: Added filters for author box social links."
 msgstr ""
 
-#: menus/menu-welcome.php:379
+#: menus/menu-welcome.php:384
 msgid "New: Inspection filter to adjust the inspection date/time format."
 msgstr ""
 
-#: menus/menu-welcome.php:380
+#: menus/menu-welcome.php:385
 msgid ""
 "New: Several author widget filters added to enable additional content through "
 "extensions or custom functions."
 msgstr ""
 
-#: menus/menu-welcome.php:381
+#: menus/menu-welcome.php:386
 msgid ""
 "New: Sold, leased, under offer label filter which uses the label setting and label "
 "changes dashboard widget, admin category filters and search widget."
 msgstr ""
 
-#: menus/menu-welcome.php:382
+#: menus/menu-welcome.php:387
 msgid "New: Sold label making Sold STC possible or other Sold label variant."
 msgstr ""
 
-#: menus/menu-welcome.php:383
+#: menus/menu-welcome.php:388
 msgid "New: Danish language thanks to pascal."
 msgstr ""
 
-#: menus/menu-welcome.php:384
+#: menus/menu-welcome.php:389
 msgid "New: German language thanks to ChriKn."
 msgstr ""
 
-#: menus/menu-welcome.php:385
+#: menus/menu-welcome.php:390
 msgid "New: Ukrainian language thanks to Alex."
 msgstr ""
 
-#: menus/menu-welcome.php:386
+#: menus/menu-welcome.php:391
 msgid "New: Swedish language thanks to Roland J."
 msgstr ""
 
-#: menus/menu-welcome.php:389
+#: menus/menu-welcome.php:394
 msgid "Version 2.1.10"
 msgstr ""
 
-#: menus/menu-welcome.php:392
+#: menus/menu-welcome.php:397
 msgid "New: Email field validation added."
 msgstr ""
 
-#: menus/menu-welcome.php:393
+#: menus/menu-welcome.php:398
 msgid "New: Added status classes to widgets for better targeting of CSS styles."
 msgstr ""
 
-#: menus/menu-welcome.php:394
+#: menus/menu-welcome.php:399
 msgid "Tweak: Improved video embed and added a filter to adjust video container size."
 msgstr ""
 
-#: menus/menu-welcome.php:395
+#: menus/menu-welcome.php:400
 msgid ""
 "Tweak: Improved CSS wrappers for listing widget and added dynamic class depending on "
 "widget display style."
 msgstr ""
 
-#: menus/menu-welcome.php:396
+#: menus/menu-welcome.php:401
 msgid "Tweak: Added additional classes to Listing Widget list variant style list items."
 msgstr ""
 
-#: menus/menu-welcome.php:397
+#: menus/menu-welcome.php:402
 msgid "Fix: Additional paging issues fixed in listing widget for other options."
 msgstr ""
 
-#: menus/menu-welcome.php:398
+#: menus/menu-welcome.php:403
 msgid "Fix: Widget leased selection displays rentals correctly."
 msgstr ""
 
-#: menus/menu-welcome.php:401
+#: menus/menu-welcome.php:406
 msgid "Version 2.1.9"
 msgstr ""
 
-#: menus/menu-welcome.php:404
+#: menus/menu-welcome.php:409
 msgid "Fix: Fixed paging issues in listing widget."
 msgstr ""
 
-#: menus/menu-welcome.php:405
+#: menus/menu-welcome.php:410
 msgid "Fix: Fix shortcodes when using multiple listing post types."
 msgstr ""
 
-#: menus/menu-welcome.php:408
+#: menus/menu-welcome.php:413
 msgid "Version 2.1.8"
 msgstr ""
 
-#: menus/menu-welcome.php:411
+#: menus/menu-welcome.php:416
 msgid "New: Ability to disable all plugin CSS from Advanced Settings section."
 msgstr ""
 
-#: menus/menu-welcome.php:412
+#: menus/menu-welcome.php:417
 msgid "New: Search widget and shortcode now have the option to turn of Location search."
 msgstr ""
 
-#: menus/menu-welcome.php:413
+#: menus/menu-welcome.php:418
 msgid ""
 "New: Search widget and shortcode now have filters to control the display of \"Any\". "
 "Each field has a unique filter which will allow you to hide the label using CSS and "
@@ -2433,15 +2441,15 @@ msgid ""
 "create super slim search boxes."
 msgstr ""
 
-#: menus/menu-welcome.php:414
+#: menus/menu-welcome.php:419
 msgid "New: Added translation Belgian (Dutch) thanks to pascal.beyens"
 msgstr ""
 
-#: menus/menu-welcome.php:415
+#: menus/menu-welcome.php:420
 msgid "New: Polish translation thanks to Weronika.urbanczyk"
 msgstr ""
 
-#: menus/menu-welcome.php:416
+#: menus/menu-welcome.php:421
 msgid ""
 "New: Two mew shortcode templates table and table_open usable with shortcodes to "
 "provide a slim list of listings. Example usage is [listing_open template=\"table\"] "
@@ -2449,310 +2457,310 @@ msgid ""
 "theme/easypropertylistings folder to further customize."
 msgstr ""
 
-#: menus/menu-welcome.php:417
+#: menus/menu-welcome.php:422
 msgid ""
 "New: Added currency support for Qatar Riyal (QAR), United Arab Emirates (AED), "
 "Ukrainian Hryvnia (UAH), Vietnamese đồng (VND)"
 msgstr ""
 
-#: menus/menu-welcome.php:418
+#: menus/menu-welcome.php:423
 msgid "New: checkbox_single ability for plugin and extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:419
+#: menus/menu-welcome.php:424
 msgid "New: Ability to disable map on each listing."
 msgstr ""
 
-#: menus/menu-welcome.php:420
+#: menus/menu-welcome.php:425
 msgid ""
 "Tweak: Updated currency symbols for: Israeli Shekel, Thai Baht, Indian Rupee, Turkish "
 "Lira, Iranian Rial."
 msgstr ""
 
-#: menus/menu-welcome.php:421
+#: menus/menu-welcome.php:426
 msgid ""
 "Tweak: Improved CSS and added additional classes with epl- prefix in templates and "
 "search."
 msgstr ""
 
-#: menus/menu-welcome.php:422
+#: menus/menu-welcome.php:427
 msgid "Tweak: Improved CSS for Location Profiles and Staff Directory extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:423
+#: menus/menu-welcome.php:428
 msgid ""
 "Tweak: Added filters for commercial titles to allow you to change \"For Lease\" and "
 "\"For Sale\" using epl_commercial_for_lease_label, and epl_commercial_for_sale_label "
 "filters."
 msgstr ""
 
-#: menus/menu-welcome.php:424
+#: menus/menu-welcome.php:429
 msgid "Tweak: Additional CSS classes for Land, Commercial and Rural special features."
 msgstr ""
 
-#: menus/menu-welcome.php:425
+#: menus/menu-welcome.php:430
 msgid "Tweak: Gallery CSS classes added."
 msgstr ""
 
-#: menus/menu-welcome.php:426
+#: menus/menu-welcome.php:431
 msgid ""
 "Tweak: Improved table shortcodes CSS and styling for better full display and "
 "responsive widths."
 msgstr ""
 
-#: menus/menu-welcome.php:427
+#: menus/menu-welcome.php:432
 msgid "Fix: New/Open Sticker now appear on listings with the price display set to no."
 msgstr ""
 
-#: menus/menu-welcome.php:428
+#: menus/menu-welcome.php:433
 msgid "Fix: Translations work correctly for categories."
 msgstr ""
 
-#: menus/menu-welcome.php:431
+#: menus/menu-welcome.php:436
 msgid "Version 2.1.7"
 msgstr ""
 
-#: menus/menu-welcome.php:434
+#: menus/menu-welcome.php:439
 msgid ""
 "New: listing_search shortcode now has style option for adjusting the width. You can "
 "add style=\"slim\" or style=\"wide\" to the shortcode to adjust the appearance."
 msgstr ""
 
-#: menus/menu-welcome.php:435
+#: menus/menu-welcome.php:440
 msgid "New: Listing Search widget now has style options for adjusting the width."
 msgstr ""
 
-#: menus/menu-welcome.php:436
+#: menus/menu-welcome.php:441
 msgid "Tweak: Updated translation and added missing sqm translation element."
 msgstr ""
 
-#: menus/menu-welcome.php:437
+#: menus/menu-welcome.php:442
 msgid "Tweak: Allowed for hundredths decimal in bathrooms field."
 msgstr ""
 
-#: menus/menu-welcome.php:438
+#: menus/menu-welcome.php:443
 msgid "Tweak: Floor plan button CSS."
 msgstr ""
 
-#: menus/menu-welcome.php:439
+#: menus/menu-welcome.php:444
 msgid "Tweak: Address and price responsive CSS."
 msgstr ""
 
-#: menus/menu-welcome.php:440
+#: menus/menu-welcome.php:445
 msgid "Fix: Auction listing price set to no displays auction date correctly."
 msgstr ""
 
-#: menus/menu-welcome.php:441
+#: menus/menu-welcome.php:446
 msgid "Fix: Fix: Author position css class."
 msgstr ""
 
-#: menus/menu-welcome.php:444
+#: menus/menu-welcome.php:449
 msgid "Version 2.1.6"
 msgstr ""
 
-#: menus/menu-welcome.php:447
+#: menus/menu-welcome.php:452
 msgid "Fix: Fancy pagination paging works correctly when shortcodes used on home page."
 msgstr ""
 
-#: menus/menu-welcome.php:448
+#: menus/menu-welcome.php:453
 msgid "Fix: Wrapped new pagination feature in esc_url to prevent vulnerability."
 msgstr ""
 
-#: menus/menu-welcome.php:449
+#: menus/menu-welcome.php:454
 msgid ""
 "Fix: Corrected sorting by price when using shortcodes. Note: Rental sorting works on "
 "post_type=\"rental\" in all shortcodes."
 msgstr ""
 
-#: menus/menu-welcome.php:450
+#: menus/menu-welcome.php:455
 msgid ""
 "Tweak: Added rental rate view for text entry of rental rates for REAXML compatibility."
 msgstr ""
 
-#: menus/menu-welcome.php:451
+#: menus/menu-welcome.php:456
 msgid ""
 "Tweak: Corrected admin display columns and edit listing pages for better display on "
 "mobile devices."
 msgstr ""
 
-#: menus/menu-welcome.php:454
+#: menus/menu-welcome.php:459
 msgid "Version 2.1.5"
 msgstr ""
 
-#: menus/menu-welcome.php:457
+#: menus/menu-welcome.php:462
 msgid ""
 "Tweak: Commercial listing: Ability to set commercial lease rate to a decimal value "
 "using the epl_price_number_format_commercial_lease filter."
 msgstr ""
 
-#: menus/menu-welcome.php:458
+#: menus/menu-welcome.php:463
 msgid "Tweak: Updated epl.pot translation file."
 msgstr ""
 
-#: menus/menu-welcome.php:459
+#: menus/menu-welcome.php:464
 msgid ""
 "Tweak: Removed horizontal line elements in the help section to match WordPress 4.2 "
 "admin page styles."
 msgstr ""
 
-#: menus/menu-welcome.php:460
+#: menus/menu-welcome.php:465
 msgid ""
 "Tweak: Rental Listing: Added epl_property_bond_position filter to adjust the position "
 "of the Bond/Deposit to appear either before or after the value."
 msgstr ""
 
-#: menus/menu-welcome.php:461
+#: menus/menu-welcome.php:466
 msgid "Tweak: Rental Listing: Removed CSS padding before bond value."
 msgstr ""
 
-#: menus/menu-welcome.php:462
+#: menus/menu-welcome.php:467
 msgid ""
 "Fix: Rental Listing: Adjusting the Bond/Deposit label will now show your custom label "
 "in the Rental Price box."
 msgstr ""
 
-#: menus/menu-welcome.php:463
+#: menus/menu-welcome.php:468
 msgid "Fix: Rural Listing: Undefined label_leased variable."
 msgstr ""
 
-#: menus/menu-welcome.php:464
+#: menus/menu-welcome.php:469
 msgid ""
 "Note: Confirmed Easy Property Listings is not vulnerable to recent WordPress exploit."
 msgstr ""
 
-#: menus/menu-welcome.php:465
+#: menus/menu-welcome.php:470
 msgid "New: Added setting to show/hide Listing Unique ID column when managing listings."
 msgstr ""
 
-#: menus/menu-welcome.php:468
+#: menus/menu-welcome.php:473
 msgid "Version 2.1.4"
 msgstr ""
 
-#: menus/menu-welcome.php:471
+#: menus/menu-welcome.php:476
 msgid "Tweak: Pagination optimised and no longer loads in admin."
 msgstr ""
 
-#: menus/menu-welcome.php:472
+#: menus/menu-welcome.php:477
 msgid "Tweak: New filter epl_price_number_format added for decimal rental rates."
 msgstr ""
 
-#: menus/menu-welcome.php:473
+#: menus/menu-welcome.php:478
 msgid "Fix: Display custom bond label when viewing listings."
 msgstr ""
 
-#: menus/menu-welcome.php:474
+#: menus/menu-welcome.php:479
 msgid ""
 "Tweak: Added filter epl_floorplan_button_label_filter to adjust Floor Plan button "
 "label."
 msgstr ""
 
-#: menus/menu-welcome.php:477
+#: menus/menu-welcome.php:482
 msgid "Version 2.1.3"
 msgstr ""
 
-#: menus/menu-welcome.php:480
+#: menus/menu-welcome.php:485
 msgid ""
 "Fix: Author box upgraded to allow for custom tabs and better extension integration "
 "with author box and widget."
 msgstr ""
 
-#: menus/menu-welcome.php:481
+#: menus/menu-welcome.php:486
 msgid "Fix: Added additional epl-author-archive CSS class for author archive pages."
 msgstr ""
 
-#: menus/menu-welcome.php:482
+#: menus/menu-welcome.php:487
 msgid "Fix: Improved CSS classes for author box with better responsive support."
 msgstr ""
 
-#: menus/menu-welcome.php:483
+#: menus/menu-welcome.php:488
 msgid "Fix: Added additional filters for author contact information."
 msgstr ""
 
-#: menus/menu-welcome.php:484
+#: menus/menu-welcome.php:489
 msgid ""
 "Fix: Added secondary global author function for simpler integration for extensions "
 "like the Staff Directory."
 msgstr ""
 
-#: menus/menu-welcome.php:485
+#: menus/menu-welcome.php:490
 msgid "Fix: Changes to author tempaltes and restored author position variable."
 msgstr ""
 
-#: menus/menu-welcome.php:486
+#: menus/menu-welcome.php:491
 msgid "Fix: Further improved max and min graph values when in listing admin."
 msgstr ""
 
-#: menus/menu-welcome.php:489
+#: menus/menu-welcome.php:494
 msgid "Version 2.1.2"
 msgstr ""
 
-#: menus/menu-welcome.php:491
+#: menus/menu-welcome.php:496
 msgid "Fix: Improved Responsive CSS for grid style."
 msgstr ""
 
-#: menus/menu-welcome.php:492
+#: menus/menu-welcome.php:497
 msgid ""
 "Fix: Twenty Fifteen, Twenty Fourteen, Twenty Thirteen, Twenty Twelve CSS styles for "
 "better display."
 msgstr ""
 
-#: menus/menu-welcome.php:493
+#: menus/menu-welcome.php:498
 msgid "New: Added CSS class theme name output to archive and single templates."
 msgstr ""
 
-#: menus/menu-welcome.php:496
+#: menus/menu-welcome.php:501
 msgid "Version 2.1.1"
 msgstr ""
 
-#: menus/menu-welcome.php:498
+#: menus/menu-welcome.php:503
 msgid ""
 "Fix: Max price defaults set for graph calculations when upgrading from pre 2.0 "
 "version."
 msgstr ""
 
-#: menus/menu-welcome.php:501
+#: menus/menu-welcome.php:506
 msgid "Version 2.1"
 msgstr ""
 
-#: menus/menu-welcome.php:503
+#: menus/menu-welcome.php:508
 msgid "New: Fancy pagination option which can be enabled in settings."
 msgstr ""
 
-#: menus/menu-welcome.php:504
+#: menus/menu-welcome.php:509
 msgid "New: Coordinates now added to listing if not set prior."
 msgstr ""
 
-#: menus/menu-welcome.php:505
+#: menus/menu-welcome.php:510
 msgid "New: Ability to select larger listing image sizes in admin."
 msgstr ""
 
-#: menus/menu-welcome.php:506
+#: menus/menu-welcome.php:511
 msgid "New: Added date picker for available date on rental listing."
 msgstr ""
 
-#: menus/menu-welcome.php:507
+#: menus/menu-welcome.php:512
 msgid "New: Added date picker for sold date."
 msgstr ""
 
-#: menus/menu-welcome.php:508
+#: menus/menu-welcome.php:513
 msgid ""
 "New: New function that combines all meta box options into one global function for "
 "admin pages."
 msgstr ""
 
-#: menus/menu-welcome.php:509
+#: menus/menu-welcome.php:514
 msgid "New: Display second agent name in admin listing lists."
 msgstr ""
 
-#: menus/menu-welcome.php:510
+#: menus/menu-welcome.php:515
 msgid "New: Additional admin option to filter by agent/author. "
 msgstr ""
 
-#: menus/menu-welcome.php:511
+#: menus/menu-welcome.php:516
 msgid "New: Shortcode [listing_location] to display listings by specific location."
 msgstr ""
 
-#: menus/menu-welcome.php:512
+#: menus/menu-welcome.php:517
 msgid ""
 "New: The following shortcodes can now be filtered by location taxonomy: [listing "
 "location=\"perth\"], [listing_open location=\"sydney\"], [listing_category location="
@@ -2760,485 +2768,485 @@ msgid ""
 "\"terrace\" location=\"new-york\"]"
 msgstr ""
 
-#: menus/menu-welcome.php:513
+#: menus/menu-welcome.php:518
 msgid ""
 "New: The following shortcodes can now be sorted by price, date and ordered by ASC and "
 "DESC [listing sortby=\"price\" sort_order=\"ASC\"]."
 msgstr ""
 
-#: menus/menu-welcome.php:514
+#: menus/menu-welcome.php:519
 msgid ""
 "New: Sorter added to shortcodes which can be enabled by adding tools_top=\"on\" to "
 "your shortcode options."
 msgstr ""
 
-#: menus/menu-welcome.php:515
+#: menus/menu-welcome.php:520
 msgid "New: Template added in table format for use in shortcodes template=\"table\"."
 msgstr ""
 
-#: menus/menu-welcome.php:516
+#: menus/menu-welcome.php:521
 msgid "New: Function to get all active post types."
 msgstr ""
 
-#: menus/menu-welcome.php:517
+#: menus/menu-welcome.php:522
 msgid "New: Ability to register additional custom post types."
 msgstr ""
 
-#: menus/menu-welcome.php:518
+#: menus/menu-welcome.php:523
 msgid "New: Extensions now have additional help text ability."
 msgstr ""
 
-#: menus/menu-welcome.php:519
+#: menus/menu-welcome.php:524
 msgid "New: All menus now use global function to render fields."
 msgstr ""
 
-#: menus/menu-welcome.php:520
+#: menus/menu-welcome.php:525
 msgid ""
 "New: Improved template output and added additional CSS wrappers for some theme and "
 "HTML5 themes."
 msgstr ""
 
-#: menus/menu-welcome.php:521
+#: menus/menu-welcome.php:526
 msgid "New: Commercial rental lease duration now selectable."
 msgstr ""
 
-#: menus/menu-welcome.php:522
+#: menus/menu-welcome.php:527
 msgid "New: Rooms field added to set the number of rooms that the listing has."
 msgstr ""
 
-#: menus/menu-welcome.php:523
+#: menus/menu-welcome.php:528
 msgid "New: Date listed field added to all listing types."
 msgstr ""
 
-#: menus/menu-welcome.php:524
+#: menus/menu-welcome.php:529
 msgid "New: Year built field added to property, rental, rural listing types."
 msgstr ""
 
-#: menus/menu-welcome.php:525
+#: menus/menu-welcome.php:530
 msgid "New: Media upload function for use in extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:526
+#: menus/menu-welcome.php:531
 msgid "New: Ability to customise Under Offer and Leased labels in settings."
 msgstr ""
 
-#: menus/menu-welcome.php:527
+#: menus/menu-welcome.php:532
 msgid ""
 "New: Lease type label loaded from dropdown select. So you can have NNN, P.A., Full "
 "Service, Gross Lease Rates, on commercial listing types. Also has a filter to enable "
 "customisation of the options."
 msgstr ""
 
-#: menus/menu-welcome.php:528
+#: menus/menu-welcome.php:533
 msgid "New: Disable links in the feature list."
 msgstr ""
 
-#: menus/menu-welcome.php:529
+#: menus/menu-welcome.php:534
 msgid "Fix: Text domain fixes on template files."
 msgstr ""
 
-#: menus/menu-welcome.php:530
+#: menus/menu-welcome.php:535
 msgid "Fix: Finnish translation file renamed."
 msgstr ""
 
-#: menus/menu-welcome.php:531
+#: menus/menu-welcome.php:536
 msgid "Fix: FeedSync date processor strptime function corrected."
 msgstr ""
 
-#: menus/menu-welcome.php:532
+#: menus/menu-welcome.php:537
 msgid ""
 "Fix: Bug in parking search field. Was only searching carports and not garages. Now "
 "searches both."
 msgstr ""
 
-#: menus/menu-welcome.php:533
+#: menus/menu-welcome.php:538
 msgid "Fix: New label now appears on listings not just with an inspection time saved."
 msgstr ""
 
-#: menus/menu-welcome.php:534
+#: menus/menu-welcome.php:539
 msgid "Tweak: Optimised loading of admin scripts and styles to pages where required."
 msgstr ""
 
-#: menus/menu-welcome.php:535
+#: menus/menu-welcome.php:540
 msgid ""
 "Tweak: Added version to CSS and JS so new versions are automatically used when plugin "
 "is updated."
 msgstr ""
 
-#: menus/menu-welcome.php:536
+#: menus/menu-welcome.php:541
 msgid "Tweak: Tidy up of admin CSS."
 msgstr ""
 
-#: menus/menu-welcome.php:537
+#: menus/menu-welcome.php:542
 msgid "Tweak: Video in author box now responsive."
 msgstr ""
 
-#: menus/menu-welcome.php:538
+#: menus/menu-welcome.php:543
 msgid ""
 "Tweak: Increased characters possible in address block fields from 40 to 80 characters "
 "and heading block to 200."
 msgstr ""
 
-#: menus/menu-welcome.php:539
+#: menus/menu-welcome.php:544
 msgid "Tweak: Coordinates now correctly being used to generate map."
 msgstr ""
 
-#: menus/menu-welcome.php:540
+#: menus/menu-welcome.php:545
 msgid "Tweak: Inspection times improved style in admin."
 msgstr ""
 
-#: menus/menu-welcome.php:541
+#: menus/menu-welcome.php:546
 msgid "Tweak: Commercial rental rate now accepts decimal numbers."
 msgstr ""
 
-#: menus/menu-welcome.php:542
+#: menus/menu-welcome.php:547
 msgid "Tweak: Improved google map output."
 msgstr ""
 
-#: menus/menu-welcome.php:543
+#: menus/menu-welcome.php:548
 msgid "Tweak: Improved default settings on upgrade, install and multisite."
 msgstr ""
 
-#: menus/menu-welcome.php:544
+#: menus/menu-welcome.php:549
 msgid "Tweak: Scripts improve site speed."
 msgstr ""
 
-#: menus/menu-welcome.php:545
+#: menus/menu-welcome.php:550
 msgid "Tweak: Dashboard widget improved query."
 msgstr ""
 
-#: menus/menu-welcome.php:546
+#: menus/menu-welcome.php:551
 msgid "Tweak: Front end CSS tweaks for better responsiveness."
 msgstr ""
 
-#: menus/menu-welcome.php:549
+#: menus/menu-welcome.php:554
 msgid "Version 2.0.3"
 msgstr ""
 
-#: menus/menu-welcome.php:551
+#: menus/menu-welcome.php:556
 msgid "Fix: Manually entered inspection capitalization fixed pM to PM."
 msgstr ""
 
-#: menus/menu-welcome.php:552
+#: menus/menu-welcome.php:557
 msgid "New: French translation (Thanks to Thomas Grimaud)"
 msgstr ""
 
-#: menus/menu-welcome.php:553
+#: menus/menu-welcome.php:558
 msgid "New: Finnish translation (Thanks to Turo)"
 msgstr ""
 
-#: menus/menu-welcome.php:556
+#: menus/menu-welcome.php:561
 msgid "Version 2.0.2"
 msgstr ""
 
-#: menus/menu-welcome.php:558
+#: menus/menu-welcome.php:563
 msgid ""
 "Fix: Added fall-back diff() function which is not present in PHP 5.2 or earlier used "
 "with the New label."
 msgstr ""
 
-#: menus/menu-welcome.php:559
+#: menus/menu-welcome.php:564
 msgid ""
 "Fix: Some Labels in settings were not saving correctly particularly the search widget "
 "labels."
 msgstr ""
 
-#: menus/menu-welcome.php:560
+#: menus/menu-welcome.php:565
 msgid "Fix: Restored missing author profile contact form tab on author box."
 msgstr ""
 
-#: menus/menu-welcome.php:561
+#: menus/menu-welcome.php:566
 msgid "Tweak: Added CSS version to admin CSS and front end CSS."
 msgstr ""
 
-#: menus/menu-welcome.php:564
+#: menus/menu-welcome.php:569
 msgid "Version 2.0.1"
 msgstr ""
 
-#: menus/menu-welcome.php:566
+#: menus/menu-welcome.php:571
 msgid ""
 "Fix: Attempted Twenty 15 CSS Fix but causes issues with other themes. Manual fix: "
 "Copy CSS from style-front.css to correct, margins and grid/sorter."
 msgstr ""
 
-#: menus/menu-welcome.php:567
+#: menus/menu-welcome.php:572
 msgid ""
 "Fix: Restored Display of Inspection Label for properties with scheduled inspection "
 "times."
 msgstr ""
 
-#: menus/menu-welcome.php:568
+#: menus/menu-welcome.php:573
 msgid "Fix: Search Widget security fix and performance improvements."
 msgstr ""
 
-#: menus/menu-welcome.php:571
+#: menus/menu-welcome.php:576
 msgid "Version 2.0"
 msgstr ""
 
-#: menus/menu-welcome.php:573
+#: menus/menu-welcome.php:578
 msgid "New: Extension validator."
 msgstr ""
 
-#: menus/menu-welcome.php:574
+#: menus/menu-welcome.php:579
 msgid "New: Depreciated listing-meta.php into compatibility folder."
 msgstr ""
 
-#: menus/menu-welcome.php:575
+#: menus/menu-welcome.php:580
 msgid "New: Depreciated author-meta.php into compatibility folder."
 msgstr ""
 
-#: menus/menu-welcome.php:576
+#: menus/menu-welcome.php:581
 msgid "New: Global variables: $property, $epl_author and $epl_settings."
 msgstr ""
 
-#: menus/menu-welcome.php:577
+#: menus/menu-welcome.php:582
 msgid "New: Added filters for fields and groups in /lib/meta-boxes.php"
 msgstr ""
 
-#: menus/menu-welcome.php:578
+#: menus/menu-welcome.php:583
 msgid ""
 "New: Property custom meta re-written into class. This was the big change to 2.0 where "
 "we completely re-wrote the output of the meta values which are now accessible using "
 "global $property variable and easy template actions."
 msgstr ""
 
-#: menus/menu-welcome.php:579
+#: menus/menu-welcome.php:584
 msgid ""
 "New: Property meta can now can be output using new actions for easy and quick custom "
 "template creation."
 msgstr ""
 
-#: menus/menu-welcome.php:580
+#: menus/menu-welcome.php:585
 msgid "New: Reconstructed templates for single, archive & author pages"
 msgstr ""
 
-#: menus/menu-welcome.php:581
+#: menus/menu-welcome.php:586
 msgid "Tweak: Removed unused price script"
 msgstr ""
 
-#: menus/menu-welcome.php:582
+#: menus/menu-welcome.php:587
 msgid "Fix: Fixed warning related to static instance in strict standard modes"
 msgstr ""
 
-#: menus/menu-welcome.php:583
+#: menus/menu-welcome.php:588
 msgid "New: API for extensions now support WordPress editor with validation."
 msgstr ""
 
-#: menus/menu-welcome.php:584
+#: menus/menu-welcome.php:589
 msgid ""
 "New: jQuery date time picker formatting added to improve support for auction and sold "
 "listing, support for 30+ languages support."
 msgstr ""
 
-#: menus/menu-welcome.php:585
+#: menus/menu-welcome.php:590
 msgid ""
 "New: Inspection time auto-formats REAXML date eg [13-Dec-2014 11:00am to 11:45am] and "
 "will no longer show past inspection times."
 msgstr ""
 
-#: menus/menu-welcome.php:586
+#: menus/menu-welcome.php:591
 msgid "New: Inspection time support multiple dates written one per line."
 msgstr ""
 
-#: menus/menu-welcome.php:587
+#: menus/menu-welcome.php:592
 msgid "Tweak: CSS improved with better commenting and size reduction."
 msgstr ""
 
-#: menus/menu-welcome.php:588
+#: menus/menu-welcome.php:593
 msgid ""
 "New: Dashboard widget now lists all listing status so at a glance you can see your "
 "property stock."
 msgstr ""
 
-#: menus/menu-welcome.php:589
+#: menus/menu-welcome.php:594
 msgid ""
 "New: Display: To enable grid, list and sorter your custom archive-listing.php "
 "template requires the new action hook epl_template_before_property_loop before the "
 "WordPress loop."
 msgstr ""
 
-#: menus/menu-welcome.php:590
+#: menus/menu-welcome.php:595
 msgid ""
 "New: Display: Utility hook action hook added epl_template_after_property_loop for "
 "future updates."
 msgstr ""
 
-#: menus/menu-welcome.php:591
+#: menus/menu-welcome.php:596
 msgid "New: Display: List and grid view with optional masonry effect."
 msgstr ""
 
-#: menus/menu-welcome.php:592
+#: menus/menu-welcome.php:597
 msgid "New: Display: Sorter added for price high/low and date newest/oldest."
 msgstr ""
 
-#: menus/menu-welcome.php:593
+#: menus/menu-welcome.php:598
 msgid "New: Auction Date formats nicely. EG [Auction Saturday 28th December at 2:00pm]."
 msgstr ""
 
-#: menus/menu-welcome.php:594
+#: menus/menu-welcome.php:599
 msgid ""
 "New: Tabbed extensions page support in admin for advanced extensions like Listing "
 "Alerts."
 msgstr ""
 
-#: menus/menu-welcome.php:595
+#: menus/menu-welcome.php:600
 msgid "New: Multiple author support in Author Box."
 msgstr ""
 
-#: menus/menu-welcome.php:596
+#: menus/menu-welcome.php:601
 msgid ""
 "New: Search Widget - Supports multiple listing types, hold Ctrl to enable tabbed "
 "front end display."
 msgstr ""
 
-#: menus/menu-welcome.php:597
+#: menus/menu-welcome.php:602
 msgid ""
 "New: Search Widget - Labels are configurable from the Display settings allowing you "
 "to set for example: Property to Buy and Rental to Rent and use a single widget to "
 "search multiple types."
 msgstr ""
 
-#: menus/menu-welcome.php:598
+#: menus/menu-welcome.php:603
 msgid ""
 "New: Search Widget and shortcode supports search by property ID, post Title, Land "
 "Area and Building Area."
 msgstr ""
 
-#: menus/menu-welcome.php:599
+#: menus/menu-welcome.php:604
 msgid ""
 "New: Search Widget - removed extra fields from land, added labels for each property "
 "type to be shown as tab heading in search widget"
 msgstr ""
 
-#: menus/menu-welcome.php:600
+#: menus/menu-welcome.php:605
 msgid ""
 "Fix: Search Widget - Optimized total queries due to search widget from 1500 + to ~40"
 msgstr ""
 
-#: menus/menu-welcome.php:601
+#: menus/menu-welcome.php:606
 msgid "New: Author variables accessible using new CLASS."
 msgstr ""
 
-#: menus/menu-welcome.php:602
+#: menus/menu-welcome.php:607
 msgid "New: Search short code supports array of property types."
 msgstr ""
 
-#: menus/menu-welcome.php:603
+#: menus/menu-welcome.php:608
 msgid ""
 "New: REAXML date format function to format date correctly when using WP All Import "
 "Pro. Usage [epl_feedsync_format_date({./@modTime})]."
 msgstr ""
 
-#: menus/menu-welcome.php:604
+#: menus/menu-welcome.php:609
 msgid ""
 "New: REAXML Unit and lot formatting function for usage in the title when using WP All "
 "Import Pro. Usage [epl_feedsync_filter_sub_number({address[1]/subNumber[1]})]."
 msgstr ""
 
-#: menus/menu-welcome.php:605
+#: menus/menu-welcome.php:610
 msgid ""
 "New: Global $epl_settings settings variable adds new default values on plugin update."
 msgstr ""
 
-#: menus/menu-welcome.php:606
+#: menus/menu-welcome.php:611
 msgid "New: Display: Added customisable label for rental Bond/Deposit."
 msgstr ""
 
-#: menus/menu-welcome.php:607
+#: menus/menu-welcome.php:612
 msgid ""
 "New: Template functions completely re-written and can now be output using actions."
 msgstr ""
 
-#: menus/menu-welcome.php:608
+#: menus/menu-welcome.php:613
 msgid ""
 "New: Added NEW sticker with customisable label and ability to set how long a listing "
 "displays the new label."
 msgstr ""
 
-#: menus/menu-welcome.php:609
+#: menus/menu-welcome.php:614
 msgid "Tweak: Compatibility fixes"
 msgstr ""
 
-#: menus/menu-welcome.php:610
+#: menus/menu-welcome.php:615
 msgid "New: Bar Graph API added."
 msgstr ""
 
-#: menus/menu-welcome.php:611
+#: menus/menu-welcome.php:616
 msgid ""
 "New: Graph in admin allows you to set the max bar graph value. Default are (2,000,000 "
 "sale) and (2,000 rental)."
 msgstr ""
 
-#: menus/menu-welcome.php:612
+#: menus/menu-welcome.php:617
 msgid "New: Graph visually displays price and status."
 msgstr ""
 
-#: menus/menu-welcome.php:613
+#: menus/menu-welcome.php:618
 msgid ""
 "New: Price graph now appears in admin pages quickly highlighting price and status "
 "visually."
 msgstr ""
 
-#: menus/menu-welcome.php:614
+#: menus/menu-welcome.php:619
 msgid "New: Meta Fields: Support for unit number, lot number (land)."
 msgstr ""
 
-#: menus/menu-welcome.php:615
+#: menus/menu-welcome.php:620
 msgid "New: South African ZAR currency support."
 msgstr ""
 
-#: menus/menu-welcome.php:616
+#: menus/menu-welcome.php:621
 msgid "Fix: Corrected Commercial Features ID Spelling"
 msgstr ""
 
-#: menus/menu-welcome.php:617
+#: menus/menu-welcome.php:622
 msgid ""
 "Tweak: YouTube video src to id function is replaced with better method which handles "
 "multiple YouTube video formats including shortened & embedded format"
 msgstr ""
 
-#: menus/menu-welcome.php:618
+#: menus/menu-welcome.php:623
 msgid "New: Adding Sold Date processing"
 msgstr ""
 
-#: menus/menu-welcome.php:619
+#: menus/menu-welcome.php:624
 msgid "Tweak: Updated shortcode templates"
 msgstr ""
 
-#: menus/menu-welcome.php:620
+#: menus/menu-welcome.php:625
 msgid "Tweak: Global $epl_author."
 msgstr ""
 
-#: menus/menu-welcome.php:621
+#: menus/menu-welcome.php:626
 msgid "Tweak: Fixed content/ into EPL_PATH_TEMPLATES_CONTENT"
 msgstr ""
 
-#: menus/menu-welcome.php:622
+#: menus/menu-welcome.php:627
 msgid "New: Support for older extensions added"
 msgstr ""
 
-#: menus/menu-welcome.php:623
+#: menus/menu-welcome.php:628
 msgid "New: Extension offers in menus general tab"
 msgstr ""
 
-#: menus/menu-welcome.php:624
+#: menus/menu-welcome.php:629
 msgid ""
 "Tweak: Renamed user profile options section to [Easy Property Listings: Author Box "
 "Profile]."
 msgstr ""
 
-#: menus/menu-welcome.php:625
+#: menus/menu-welcome.php:630
 msgid "Tweak: Added better Bond/Deposit for rentals labels."
 msgstr ""
 
-#: menus/menu-welcome.php:626
+#: menus/menu-welcome.php:631
 msgid ""
 "Fix: Deprecated author-meta.php in compatibility folder, class-author-meta.php has "
 "been created which will be used in place of author-meta.php & its variables in all "
 "author templates"
 msgstr ""
 
-#: menus/menu-welcome.php:627
+#: menus/menu-welcome.php:632
 msgid ""
 "New: Added template functions for author meta class, modified templates lib/templates/"
 "content/content-author-box-simple-card.php lib/templates/content/content-author-box-"
@@ -3246,545 +3254,545 @@ msgid ""
 "functions based on author meta class instead of variables from author-meta.php"
 msgstr ""
 
-#: menus/menu-welcome.php:628
+#: menus/menu-welcome.php:633
 msgid ""
 "New: author-meta.php depreciated and moved to compatibility directory. Variables "
 "globally available using $epl_author variable."
 msgstr ""
 
-#: menus/menu-welcome.php:629
+#: menus/menu-welcome.php:634
 msgid ""
 "Tweak: listing-meta.php depreciated and moved to compatibility directory. Variables "
 "globally available with $property variable."
 msgstr ""
 
-#: menus/menu-welcome.php:630
+#: menus/menu-welcome.php:635
 msgid ""
 "Tweak: Added Listing not Found to default templates when search performed with no "
 "results."
 msgstr ""
 
-#: menus/menu-welcome.php:631
+#: menus/menu-welcome.php:636
 msgid "Tweak: Improved Google maps address output for addresses containing # and /."
 msgstr ""
 
-#: menus/menu-welcome.php:632
+#: menus/menu-welcome.php:637
 msgid ""
 "Fix: Listing Pages now have better responsive support for small screen devices like "
 "iPhone."
 msgstr ""
 
-#: menus/menu-welcome.php:633
+#: menus/menu-welcome.php:638
 msgid ""
 "Fix: Default templates for Genesis and TwentyTwelve now show Listing Not Found when a "
 "search result returns empty."
 msgstr ""
 
-#: menus/menu-welcome.php:634
+#: menus/menu-welcome.php:639
 msgid "Fix: Purged translations in epl.pot file."
 msgstr ""
 
-#: menus/menu-welcome.php:635
+#: menus/menu-welcome.php:640
 msgid "Fix: Search Widget and short code drastically reduces database queries."
 msgstr ""
 
-#: menus/menu-welcome.php:636
+#: menus/menu-welcome.php:641
 msgid ""
 "New: Templates are now able to be saved in active theme folder /easypropertylistings "
 "and edited. Plugin will use these first and fall back to plugin if not located in "
 "theme folder."
 msgstr ""
 
-#: menus/menu-welcome.php:637
+#: menus/menu-welcome.php:642
 msgid "Fix: Extensions Notification and checker updated"
 msgstr ""
 
-#: menus/menu-welcome.php:638
+#: menus/menu-welcome.php:643
 msgid "New: updated author templates to use new author meta class"
 msgstr ""
 
-#: menus/menu-welcome.php:639
+#: menus/menu-welcome.php:644
 msgid ""
 "Fix: Added prefix to CSS tab-content class. Now epl-tab-content for compatibility."
 msgstr ""
 
-#: menus/menu-welcome.php:640
+#: menus/menu-welcome.php:645
 msgid "New: Update user.php"
 msgstr ""
 
-#: menus/menu-welcome.php:641
+#: menus/menu-welcome.php:646
 msgid "Tweak: Improved internal documentation and updated screens."
 msgstr ""
 
-#: menus/menu-welcome.php:642
+#: menus/menu-welcome.php:647
 msgid "Tweak: Improved descriptions on author pages."
 msgstr ""
 
-#: menus/menu-welcome.php:643
+#: menus/menu-welcome.php:648
 msgid "Tweak: Better permalink flushing on activation, deactivation and install."
 msgstr ""
 
-#: menus/menu-welcome.php:644
+#: menus/menu-welcome.php:649
 msgid "Tweak: Extensive changes to admin descriptions and labels."
 msgstr ""
 
-#: menus/menu-welcome.php:645
+#: menus/menu-welcome.php:650
 msgid "Tweak: Optimising the php loading of files and scripts."
 msgstr ""
 
-#: menus/menu-welcome.php:646
+#: menus/menu-welcome.php:651
 msgid "New: Define EPL_RUNNING added for extensions to check if plugin is active."
 msgstr ""
 
-#: menus/menu-welcome.php:647
+#: menus/menu-welcome.php:652
 msgid "New: New options added to setting array when plugin is updated."
 msgstr ""
 
-#: menus/menu-welcome.php:648
+#: menus/menu-welcome.php:653
 msgid ""
 "New: Old functions and files moved to plug-in /compatibility folder to ensure old "
 "code still works."
 msgstr ""
 
-#: menus/menu-welcome.php:649
+#: menus/menu-welcome.php:654
 msgid "New: Meta Location Label."
 msgstr ""
 
-#: menus/menu-welcome.php:650
+#: menus/menu-welcome.php:655
 msgid "New: Service banners on settings page."
 msgstr ""
 
-#: menus/menu-welcome.php:651
+#: menus/menu-welcome.php:656
 msgid "New: Saving version number so when updating new settings are added."
 msgstr ""
 
-#: menus/menu-welcome.php:652
+#: menus/menu-welcome.php:657
 msgid ""
 "New: iCal functionality for REAXML formatted inspection dates. Further improvements "
 "coming for manual date entry. "
 msgstr ""
 
-#: menus/menu-welcome.php:653
+#: menus/menu-welcome.php:658
 msgid "New: Extensions options pages now with tabs for easier usage."
 msgstr ""
 
-#: menus/menu-welcome.php:654
+#: menus/menu-welcome.php:659
 msgid "New: Added ID classes to admin pages and meta fields."
 msgstr ""
 
-#: menus/menu-welcome.php:655
+#: menus/menu-welcome.php:660
 msgid "New: Filters to adjust land and building sizes from number to select fields."
 msgstr ""
 
-#: menus/menu-welcome.php:656
+#: menus/menu-welcome.php:661
 msgid ""
 "Tweak: Moved old extensions options page to compatibility folder so older extensions "
 "still work as expected."
 msgstr ""
 
-#: menus/menu-welcome.php:657
+#: menus/menu-welcome.php:662
 msgid ""
 "New: Search Widget - Added filter for land min & max fields in listing search widget"
 msgstr ""
 
-#: menus/menu-welcome.php:658
+#: menus/menu-welcome.php:663
 msgid ""
 "New: Search Widget - Added filter for building min & max fields in listing search "
 "widget"
 msgstr ""
 
-#: menus/menu-welcome.php:659
+#: menus/menu-welcome.php:664
 msgid "Fix: For session start effecting certain themes"
 msgstr ""
 
-#: menus/menu-welcome.php:660
+#: menus/menu-welcome.php:665
 msgid "New: Land sizes now allow up to 5 decimal places"
 msgstr ""
 
-#: menus/menu-welcome.php:661
+#: menus/menu-welcome.php:666
 msgid "New: Search Widget - Custom submit label"
 msgstr ""
 
-#: menus/menu-welcome.php:662
+#: menus/menu-welcome.php:667
 msgid "New: Search Widget - Can search by title in property ID / Address field"
 msgstr ""
 
-#: menus/menu-welcome.php:663
+#: menus/menu-welcome.php:668
 msgid "New: Added Russian Translation"
 msgstr ""
 
-#: menus/menu-welcome.php:666
+#: menus/menu-welcome.php:671
 msgid "Version 1.2.1"
 msgstr ""
 
-#: menus/menu-welcome.php:668
+#: menus/menu-welcome.php:673
 msgid "Fix: Search Widget not working on page 2 of archive page in some instances"
 msgstr ""
 
-#: menus/menu-welcome.php:669
+#: menus/menu-welcome.php:674
 msgid ""
 "Fix: Property feature list Toilet and New Construction now display in list when ticked"
 msgstr ""
 
-#: menus/menu-welcome.php:670
+#: menus/menu-welcome.php:675
 msgid "Fix: EPL - Listing widget was not displaying featured listings"
 msgstr ""
 
-#: menus/menu-welcome.php:671
+#: menus/menu-welcome.php:676
 msgid ""
 "Fix: Allowed to filter by commercial_listing_type in [listing_category] shortcode"
 msgstr ""
 
-#: menus/menu-welcome.php:672
+#: menus/menu-welcome.php:677
 msgid "Fix: Updated templates to display Search Results when performing search"
 msgstr ""
 
-#: menus/menu-welcome.php:673
+#: menus/menu-welcome.php:678
 msgid "Fix: No longer show Bond when viewing rental list in admin"
 msgstr ""
 
-#: menus/menu-welcome.php:674
+#: menus/menu-welcome.php:679
 msgid "Fix: Open for inspection sticker now appears on rental properties"
 msgstr ""
 
-#: menus/menu-welcome.php:675
+#: menus/menu-welcome.php:680
 msgid "New: Added initial Dutch translation."
 msgstr ""
 
-#: menus/menu-welcome.php:678
+#: menus/menu-welcome.php:683
 msgid "Version 1.2"
 msgstr ""
 
-#: menus/menu-welcome.php:680
+#: menus/menu-welcome.php:685
 msgid "New: Plug in Activation process flushes permalinks"
 msgstr ""
 
-#: menus/menu-welcome.php:681
+#: menus/menu-welcome.php:686
 msgid "New: Plug in deactivation flushes permalinks"
 msgstr ""
 
-#: menus/menu-welcome.php:682
+#: menus/menu-welcome.php:687
 msgid "New: Shortcode [listing_search]"
 msgstr ""
 
-#: menus/menu-welcome.php:683
+#: menus/menu-welcome.php:688
 msgid "New: Shortcode [listing_feature]"
 msgstr ""
 
-#: menus/menu-welcome.php:684
+#: menus/menu-welcome.php:689
 msgid ""
 "New: Shortcode [listing_open] replaces [home_open] shortcode. Retained [home_open] "
 "for backward compatibility, however adjust your site. "
 msgstr ""
 
-#: menus/menu-welcome.php:685
+#: menus/menu-welcome.php:690
 msgid ""
 "New: Listing shortcodes allow for default template display if registered by adding "
 "template=\"slim\" to the shortcode."
 msgstr ""
 
-#: menus/menu-welcome.php:686
+#: menus/menu-welcome.php:691
 msgid "New: Translation support now correctly loads text domain epl"
 msgstr ""
 
-#: menus/menu-welcome.php:687
+#: menus/menu-welcome.php:692
 msgid "New: Added translation tags to all test elements for better translation support"
 msgstr ""
 
-#: menus/menu-welcome.php:688
+#: menus/menu-welcome.php:693
 msgid "New: Updated source epl.pot translation file for translations"
 msgstr ""
 
-#: menus/menu-welcome.php:689
+#: menus/menu-welcome.php:694
 msgid "New: Added very rough Italian translation"
 msgstr ""
 
-#: menus/menu-welcome.php:690
+#: menus/menu-welcome.php:695
 msgid ""
 "New: Wrapped Featured image in action to allow for easy removal and/or replacement"
 msgstr ""
 
-#: menus/menu-welcome.php:691
+#: menus/menu-welcome.php:696
 msgid "Fix: Undefined errors when debug is active"
 msgstr ""
 
-#: menus/menu-welcome.php:692
+#: menus/menu-welcome.php:697
 msgid "New: Added new CSS classes to widgets for consistent usage"
 msgstr ""
 
-#: menus/menu-welcome.php:693
+#: menus/menu-welcome.php:698
 msgid "Tweak: Admin CSS tweaks to define sections in admin"
 msgstr ""
 
-#: menus/menu-welcome.php:694
+#: menus/menu-welcome.php:699
 msgid "Fix: CSS for TwentyThirteen style CSS using .sidebar container"
 msgstr ""
 
-#: menus/menu-welcome.php:695
+#: menus/menu-welcome.php:700
 msgid "Fix: CSS for responsive shortcode"
 msgstr ""
 
-#: menus/menu-welcome.php:696
+#: menus/menu-welcome.php:701
 msgid ""
 "New: Added options to hide/ show various options to EPL - Listing widget: Property "
 "Headline, Excerpt, Suburb/Location Label, Street Address, Price, Read More Button"
 msgstr ""
 
-#: menus/menu-welcome.php:697
+#: menus/menu-welcome.php:702
 msgid "New: Added customisable \"Read More\" label to EPL - Listing widget"
 msgstr ""
 
-#: menus/menu-welcome.php:698
+#: menus/menu-welcome.php:703
 msgid "New: Added excerpt to EPL - Listing widget"
 msgstr ""
 
-#: menus/menu-welcome.php:699
+#: menus/menu-welcome.php:704
 msgid "New: Added options to remove search options from EPL - Listing Search widget"
 msgstr ""
 
-#: menus/menu-welcome.php:700
+#: menus/menu-welcome.php:705
 msgid "New: Added consistent CSS classes to shortcodes for responsive shortcode"
 msgstr ""
 
-#: menus/menu-welcome.php:701
+#: menus/menu-welcome.php:706
 msgid ""
 "New: Date processing function for use with WP All Import when importing REAXML files. "
 "Some imports set the current date instead of the date from the REAXML file. Usage in "
 "WP All Import Post Date is: [epl_feedsync_format_date({./@modTime})]"
 msgstr ""
 
-#: menus/menu-welcome.php:702
+#: menus/menu-welcome.php:707
 msgid ""
 "Tweak: Added additional CSS classes to admin menu pages to extensions can be better "
 "distinguished when installed and activated"
 msgstr ""
 
-#: menus/menu-welcome.php:703
+#: menus/menu-welcome.php:708
 msgid "Fix: Registering custom template actions now works correctly"
 msgstr ""
 
-#: menus/menu-welcome.php:704
+#: menus/menu-welcome.php:709
 msgid "New: Added additional CSS classes to template files"
 msgstr ""
 
-#: menus/menu-welcome.php:705
+#: menus/menu-welcome.php:710
 msgid ""
 "Fix: Changed property not found wording when using search widget and listing not "
 "found. "
 msgstr ""
 
-#: menus/menu-welcome.php:706
+#: menus/menu-welcome.php:711
 msgid "Tweak: Added defaults to widgets to prevent errors when debug is on"
 msgstr ""
 
-#: menus/menu-welcome.php:707
+#: menus/menu-welcome.php:712
 msgid "New: Added WordPress editor support in admin for use with extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:708
+#: menus/menu-welcome.php:713
 msgid "New: Added textarea support in admin for use with extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:709
+#: menus/menu-welcome.php:714
 msgid ""
 "New: Filters added for all select options on add listing pages which allows for full "
 "customisation through simple function"
 msgstr ""
 
-#: menus/menu-welcome.php:710
+#: menus/menu-welcome.php:715
 msgid "New: Added rent period, Day, Daily, Month, Monthly to rental listing types"
 msgstr ""
 
-#: menus/menu-welcome.php:711
+#: menus/menu-welcome.php:716
 msgid "New: Added property_office_id meta field"
 msgstr ""
 
-#: menus/menu-welcome.php:712
+#: menus/menu-welcome.php:717
 msgid "New: Added property_address_country meta field"
 msgstr ""
 
-#: menus/menu-welcome.php:713
+#: menus/menu-welcome.php:718
 msgid "Tweak: Allowed for decimal in bathrooms to allow for 1/2 baths eg 1.5"
 msgstr ""
 
-#: menus/menu-welcome.php:714
+#: menus/menu-welcome.php:719
 msgid ""
 "New: Added mini map to listing edit screen. Will display mini map in address block "
 "when pressing green coordinates button."
 msgstr ""
 
-#: menus/menu-welcome.php:715
+#: menus/menu-welcome.php:720
 msgid ""
 "Fix: Updated admin columns for commercial_land listing type to match other listing "
 "type"
 msgstr ""
 
-#: menus/menu-welcome.php:716
+#: menus/menu-welcome.php:721
 msgid "Fix: Swapped bedrooms/bathroom label on hover"
 msgstr ""
 
-#: menus/menu-welcome.php:717
+#: menus/menu-welcome.php:722
 msgid ""
 "New: Added filter epl_listing_meta_boxes which allows additional meta boxes to be "
 "added through filter"
 msgstr ""
 
-#: menus/menu-welcome.php:720
+#: menus/menu-welcome.php:725
 msgid "Version 1.1.1"
 msgstr ""
 
-#: menus/menu-welcome.php:722
+#: menus/menu-welcome.php:727
 msgid ""
 "New: Internationalisation support to enable customizing of post types: slug, archive, "
 "rewrite, labels, listing categories for meta_types."
 msgstr ""
 
-#: menus/menu-welcome.php:723
+#: menus/menu-welcome.php:728
 msgid ""
 "New: Created filters for listing meta select fields: property_category, "
 "property_rural_category, property_commercial_category, property_land_category."
 msgstr ""
 
-#: menus/menu-welcome.php:724
+#: menus/menu-welcome.php:729
 msgid ""
 "New: Created filters for each of the seven custom post types: labels, supports, slug, "
 "archive, rewrite, seven custom post types."
 msgstr ""
 
-#: menus/menu-welcome.php:725
+#: menus/menu-welcome.php:730
 msgid ""
 "New: Shortcode [listing_category] This shortcode allows for you to output a list of "
 "listings by type and filter them by any available meta key and value."
 msgstr ""
 
-#: menus/menu-welcome.php:726
+#: menus/menu-welcome.php:731
 msgid "Tweak: Updated search widget for filtered property_categories."
 msgstr ""
 
-#: menus/menu-welcome.php:727
+#: menus/menu-welcome.php:732
 msgid "Fix: Listing categories were showing key, now showing value."
 msgstr ""
 
-#: menus/menu-welcome.php:728
+#: menus/menu-welcome.php:733
 msgid ""
 "Fix: Settings were not showing up after saving, second refresh required setting "
 "variable to reload."
 msgstr ""
 
-#: menus/menu-welcome.php:731
+#: menus/menu-welcome.php:736
 msgid "Version 1.1"
 msgstr ""
 
-#: menus/menu-welcome.php:733
+#: menus/menu-welcome.php:738
 msgid "First official release!"
 msgstr ""
 
-#: menus/menu-welcome.php:739
+#: menus/menu-welcome.php:744
 msgid "Go to Easy Property Listings Settings"
 msgstr ""
 
-#: menus/menu-welcome.php:763
+#: menus/menu-welcome.php:768
 msgid "Real Estate Tools for WordPress"
 msgstr ""
 
-#: menus/menu-welcome.php:771
+#: menus/menu-welcome.php:776
 msgid "Quick Start Guide"
 msgstr ""
 
-#: menus/menu-welcome.php:773
+#: menus/menu-welcome.php:778
 msgid ""
 "Use the tips below to get started using Easy Property Listings. You will be up and "
 "running in no time!"
 msgstr ""
 
-#: menus/menu-welcome.php:777
+#: menus/menu-welcome.php:782
 msgid "Activate the listing types you need & configure the plugin general settings"
 msgstr ""
 
-#: menus/menu-welcome.php:778 menus/menu-welcome.php:820
+#: menus/menu-welcome.php:783 menus/menu-welcome.php:825
 msgid "Create a blank page for each activated listing type"
 msgstr ""
 
-#: menus/menu-welcome.php:779
+#: menus/menu-welcome.php:784
 msgid "Publish your first listing for testing your theme setup"
 msgstr ""
 
-#: menus/menu-welcome.php:781
+#: menus/menu-welcome.php:786
 msgid "Setup your theme to work with the plugin"
 msgstr ""
 
-#: menus/menu-welcome.php:790
+#: menus/menu-welcome.php:795
 msgid "Activate the listing types you need"
 msgstr ""
 
-#: menus/menu-welcome.php:796
+#: menus/menu-welcome.php:801
 msgid ""
 "Visit the general settings page and enable the listing types you need. Once you have "
 "pressed save visit the Permalinks page to re-fresh your sites permalinks."
 msgstr ""
 
-#: menus/menu-welcome.php:798
+#: menus/menu-welcome.php:803
 msgid ""
 "Instead of classifying everything as a property, Easy Property Listings allows you to "
 "separate the different listing types which is better for SEO and RSS feeds."
 msgstr ""
 
-#: menus/menu-welcome.php:800
+#: menus/menu-welcome.php:805
 msgid "Supported Listing Types"
 msgstr ""
 
-#: menus/menu-welcome.php:825
+#: menus/menu-welcome.php:830
 msgid ""
 "Doing this allows you to add \"Property\", \"Land\" and \"Rental\" pages to your "
 "WordPress menu. Add a new page for each listing type you activated."
 msgstr ""
 
-#: menus/menu-welcome.php:827
+#: menus/menu-welcome.php:832
 msgid ""
 "For example, lets say you have activated: Property, Rental and Land. Create three "
 "pages, one called \"Property\", another \"Land\" and the third \"Rental\" these will "
 "be the custom post type slugs/permalinks eg: property, rental and land."
 msgstr ""
 
-#: menus/menu-welcome.php:829
+#: menus/menu-welcome.php:834
 msgid ""
 "Publish a test \"Property Listing\" and visit your new property page and you will see "
 "the new property and others you have created."
 msgstr ""
 
-#: menus/menu-welcome.php:831
+#: menus/menu-welcome.php:836
 msgid ""
 "Now you can rename them to whatever you like eg: \"For Sale\", \"For Rent\" etc, but "
 "leave the slug/permalink as it was,"
 msgstr ""
 
-#: menus/menu-welcome.php:831
+#: menus/menu-welcome.php:836
 msgid "this is very important."
 msgstr ""
 
-#: menus/menu-welcome.php:844
+#: menus/menu-welcome.php:849
 msgid "Publish Your First Listing"
 msgstr ""
 
-#: menus/menu-welcome.php:849
+#: menus/menu-welcome.php:854
 msgid "Title & Author"
 msgstr ""
 
-#: menus/menu-welcome.php:856
+#: menus/menu-welcome.php:861
 msgid "Use the full listing address as the title."
 msgstr ""
 
-#: menus/menu-welcome.php:858
+#: menus/menu-welcome.php:863
 msgid ""
 "When a property is being sold the \"heading\" is frequently changed and can cause "
 "permalink issues. Not to mention the search engine benefits."
 msgstr ""
 
-#: menus/menu-welcome.php:860
+#: menus/menu-welcome.php:865
 msgid "Author or Primary Real Estate Agent"
 msgstr ""
 
-#: menus/menu-welcome.php:861
+#: menus/menu-welcome.php:866
 msgid ""
 "Select the author to show the name of the agent who has listed the property with "
 "their contact details. For best results each real estate agent should have their own "
@@ -3792,257 +3800,257 @@ msgid ""
 "and in widgets."
 msgstr ""
 
-#: menus/menu-welcome.php:870
+#: menus/menu-welcome.php:875
 msgid "Gallery and Featured Image"
 msgstr ""
 
-#: menus/menu-welcome.php:875
+#: menus/menu-welcome.php:880
 msgid "Gallery"
 msgstr ""
 
-#: menus/menu-welcome.php:878
+#: menus/menu-welcome.php:883
 msgid "You can automatically output a gallery from the Display options page."
 msgstr ""
 
-#: menus/menu-welcome.php:880
+#: menus/menu-welcome.php:885
 msgid ""
 "If set to automatic, just upload your images to the listing and press x to close the "
 "media upload box once the images are attached to the listing. You can also easily "
 "adjust the number of gallery columns from the plugin Display options."
 msgstr ""
 
-#: menus/menu-welcome.php:882
+#: menus/menu-welcome.php:887
 msgid "Gallery Light Box"
 msgstr ""
 
-#: menus/menu-welcome.php:883
+#: menus/menu-welcome.php:888
 msgid ""
 "Using a light box plug-in like Easy FancyBox, your automatic gallery images will use "
 "the light box effect."
 msgstr ""
 
-#: menus/menu-welcome.php:907
+#: menus/menu-welcome.php:912
 msgid ""
 "Now supports multiple inspection times, add one per line. Past inspection dates will "
 "not display when using the new format."
 msgstr ""
 
-#: menus/menu-welcome.php:909
+#: menus/menu-welcome.php:914
 msgid ""
 "The output is now wrapped in an iCal format so clicking on the date will open the "
 "users calendar."
 msgstr ""
 
-#: menus/menu-welcome.php:922
+#: menus/menu-welcome.php:927
 msgid "Configure your theme"
 msgstr ""
 
-#: menus/menu-welcome.php:923
+#: menus/menu-welcome.php:928
 msgid ""
 "We have done our best to integrate Easy Property Listings with all WordPress themes."
 msgstr ""
 
-#: menus/menu-welcome.php:929
+#: menus/menu-welcome.php:934
 msgid ""
 "Once you add a listing and if your page is really wide or your sidebar is under the "
 "content enable Theme Compatibility mode from settings."
 msgstr ""
 
-#: menus/menu-welcome.php:931
+#: menus/menu-welcome.php:936
 msgid ""
 "Review your listing and if you are seeing double images, hop back over to Settings "
 "page and either disable the theme feature image or the one provided by Easy Property "
 "Listings."
 msgstr ""
 
-#: menus/menu-welcome.php:933
+#: menus/menu-welcome.php:938
 msgid "Shortcodes"
 msgstr ""
 
-#: menus/menu-welcome.php:935
+#: menus/menu-welcome.php:940
 msgid ""
 "The featured image settings have no impact on the Easy Property Listings shortcodes "
 "and widgets."
 msgstr ""
 
-#: menus/menu-welcome.php:940
+#: menus/menu-welcome.php:945
 msgid "Theme Compatibility not required for some themes"
 msgstr ""
 
-#: menus/menu-welcome.php:942
+#: menus/menu-welcome.php:947
 msgid "iThemes Builder Themes"
 msgstr ""
 
-#: menus/menu-welcome.php:943
+#: menus/menu-welcome.php:948
 msgid "Genesis Framework by StudioPress"
 msgstr ""
 
-#: menus/menu-welcome.php:944
+#: menus/menu-welcome.php:949
 msgid "Twenty 12, 13, 14 &#38; 15 by WordPress."
 msgstr ""
 
-#: menus/menu-welcome.php:945
+#: menus/menu-welcome.php:950
 msgid "Many others, add a listing and see how it looks."
 msgstr ""
 
-#: menus/menu-welcome.php:947
+#: menus/menu-welcome.php:952
 msgid "We have a selection of pre configured templates here for many popular themes"
 msgstr ""
 
-#: menus/menu-welcome.php:947
+#: menus/menu-welcome.php:952
 msgid "here"
 msgstr ""
 
-#: menus/menu-welcome.php:953
+#: menus/menu-welcome.php:958
 msgid "Advanced theme integration instructions"
 msgstr ""
 
-#: menus/menu-welcome.php:954
+#: menus/menu-welcome.php:959
 msgid "Before attempting the following steps add a"
 msgstr ""
 
-#: menus/menu-welcome.php:954
+#: menus/menu-welcome.php:959
 msgid "test listing"
 msgstr ""
 
-#: menus/menu-welcome.php:954
+#: menus/menu-welcome.php:959
 msgid "and preview it. Your theme may already work with Easy Property Listings."
 msgstr ""
 
-#: menus/menu-welcome.php:958
+#: menus/menu-welcome.php:963
 msgid "1. Take a backup of your theme and a copy of the files to edit."
 msgstr ""
 
-#: menus/menu-welcome.php:960
+#: menus/menu-welcome.php:965
 msgid ""
 "Open your favourite FTP program or access the file manager via your hosting panel."
 msgstr ""
 
-#: menus/menu-welcome.php:962
+#: menus/menu-welcome.php:967
 msgid "Take a backup of your theme before you start."
 msgstr ""
 
-#: menus/menu-welcome.php:964
+#: menus/menu-welcome.php:969
 msgid ""
 "Download the single.php file and archive.php from your theme folder and save it to "
 "your computer."
 msgstr ""
 
-#: menus/menu-welcome.php:965
+#: menus/menu-welcome.php:970
 msgid ""
 "If these files are not present in your child theme then copy them from your parent "
 "theme folder. If there is no archive.php file use the index.php file."
 msgstr ""
 
-#: menus/menu-welcome.php:968
+#: menus/menu-welcome.php:973
 msgid ""
 "On your computer rename single.php to single-listing.php and rename archive.php to "
 "archive-listing.php"
 msgstr ""
 
-#: menus/menu-welcome.php:970
+#: menus/menu-welcome.php:975
 msgid "If using index.php, rename that to archive-listing.php"
 msgstr ""
 
-#: menus/menu-welcome.php:972
+#: menus/menu-welcome.php:977
 msgid "Upload these new files back into your theme folder."
 msgstr ""
 
-#: menus/menu-welcome.php:976
+#: menus/menu-welcome.php:981
 msgid "2. Edit your single-listing.php file."
 msgstr ""
 
-#: menus/menu-welcome.php:978
+#: menus/menu-welcome.php:983
 msgid "Open your new single-listing.php file in your text editor like Notepad++."
 msgstr ""
 
-#: menus/menu-welcome.php:979 menus/menu-welcome.php:996
+#: menus/menu-welcome.php:984 menus/menu-welcome.php:1001
 msgid "Look for"
 msgstr ""
 
-#: menus/menu-welcome.php:980
+#: menus/menu-welcome.php:985
 msgid "which appears after"
 msgstr ""
 
-#: menus/menu-welcome.php:981 menus/menu-welcome.php:1000
+#: menus/menu-welcome.php:986 menus/menu-welcome.php:1005
 msgid "Replace"
 msgstr ""
 
-#: menus/menu-welcome.php:984
+#: menus/menu-welcome.php:989
 msgid "with"
 msgstr ""
 
-#: menus/menu-welcome.php:987 menus/menu-welcome.php:1006
+#: menus/menu-welcome.php:992 menus/menu-welcome.php:1011
 msgid "Save the file and make sure you have sent it to the server."
 msgstr ""
 
-#: menus/menu-welcome.php:988
+#: menus/menu-welcome.php:993
 msgid "View the test listing you created and you should be done."
 msgstr ""
 
-#: menus/menu-welcome.php:993
+#: menus/menu-welcome.php:998
 msgid "3. Edit your archive-listing.php file."
 msgstr ""
 
-#: menus/menu-welcome.php:995
+#: menus/menu-welcome.php:1000
 msgid "Open archive-listing.php"
 msgstr ""
 
-#: menus/menu-welcome.php:997
+#: menus/menu-welcome.php:1002
 msgid "which appears after the second"
 msgstr ""
 
-#: menus/menu-welcome.php:998
+#: menus/menu-welcome.php:1003
 msgid "The first one is usually the page title."
 msgstr ""
 
-#: menus/menu-welcome.php:1007
+#: menus/menu-welcome.php:1012
 msgid ""
 "Check the main property page <code>http://YOUR_SITE_URL/property/</code> and you "
 "should be done."
 msgstr ""
 
-#: menus/menu-welcome.php:1012
+#: menus/menu-welcome.php:1017
 msgid "4. Optional for grid and sorter. Edit your archive-listing.php file again."
 msgstr ""
 
-#: menus/menu-welcome.php:1014 menus/menu-welcome.php:1021
+#: menus/menu-welcome.php:1019 menus/menu-welcome.php:1026
 msgid "Insert"
 msgstr ""
 
-#: menus/menu-welcome.php:1017
+#: menus/menu-welcome.php:1022
 msgid "Before the second"
 msgstr ""
 
-#: menus/menu-welcome.php:1019
+#: menus/menu-welcome.php:1024
 msgid ""
 "Check your main property page, if the buttons are in the incorrect place move them "
 "until they are in the correct place."
 msgstr ""
 
-#: menus/menu-welcome.php:1022
+#: menus/menu-welcome.php:1027
 msgid "After the second"
 msgstr ""
 
-#: menus/menu-welcome.php:1030
+#: menus/menu-welcome.php:1035
 msgid "Stuck getting your theme to work?"
 msgstr ""
 
-#: menus/menu-welcome.php:1031
+#: menus/menu-welcome.php:1036
 msgid ""
 "Not all themes follow modern WordPress coding standards and these may take a little "
 "more time and experience to get working. If you just can not get it to work, visit"
 msgstr ""
 
-#: menus/menu-welcome.php:1031
+#: menus/menu-welcome.php:1036
 msgid "premium support"
 msgstr ""
 
-#: menus/menu-welcome.php:1031
+#: menus/menu-welcome.php:1036
 msgid "and fill out a theme support request."
 msgstr ""
 
-#: menus/menu-welcome.php:1033
+#: menus/menu-welcome.php:1038
 msgid ""
 "If the theme is available in the WordPress.org theme directory let us know the theme "
 "name and URL where we can download it in your support ticket. If its a premium theme "
@@ -4050,60 +4058,60 @@ msgid ""
 "download link to it on a file sharing site like Dropbox."
 msgstr ""
 
-#: menus/menu-welcome.php:1035
+#: menus/menu-welcome.php:1040
 msgid "Need Help?"
 msgstr ""
 
-#: menus/menu-welcome.php:1039
+#: menus/menu-welcome.php:1044
 msgid "Premium Support"
 msgstr ""
 
-#: menus/menu-welcome.php:1040
+#: menus/menu-welcome.php:1045
 #, php-format
 msgid ""
 "We do our best to provide the best support we can. If you encounter a problem or have "
 "a question, post a question in the <a href=\"%s\">support forums</a>."
 msgstr ""
 
-#: menus/menu-welcome.php:1044
+#: menus/menu-welcome.php:1049
 msgid "Need Even Faster Support?"
 msgstr ""
 
-#: menus/menu-welcome.php:1045
+#: menus/menu-welcome.php:1050
 msgid ""
 "<a href=\"http://easypropertylistings.com.au/support/pricing/\">Priority Support "
 "forums</a> are there for customers that need faster and/or more in-depth assistance."
 msgstr ""
 
-#: menus/menu-welcome.php:1049
+#: menus/menu-welcome.php:1054
 msgid "Documentation and Short Codes"
 msgstr ""
 
-#: menus/menu-welcome.php:1050
+#: menus/menu-welcome.php:1055
 msgid "Read the"
 msgstr ""
 
-#: menus/menu-welcome.php:1050
+#: menus/menu-welcome.php:1055
 msgid "documentation"
 msgstr ""
 
-#: menus/menu-welcome.php:1050
+#: menus/menu-welcome.php:1055
 msgid " and instructions on how to use the included"
 msgstr ""
 
-#: menus/menu-welcome.php:1050
+#: menus/menu-welcome.php:1055
 msgid "shortcodes"
 msgstr ""
 
-#: menus/menu-welcome.php:1059
+#: menus/menu-welcome.php:1064
 msgid "Stay Up to Date"
 msgstr ""
 
-#: menus/menu-welcome.php:1060
+#: menus/menu-welcome.php:1065
 msgid "Get Notified of Extension Releases"
 msgstr ""
 
-#: menus/menu-welcome.php:1061
+#: menus/menu-welcome.php:1066
 msgid ""
 "New extensions that make Easy Property Listings even more powerful are released "
 "nearly every single week. Subscribe to the newsletter to stay up to date with our "
@@ -4111,25 +4119,25 @@ msgid ""
 "a> to ensure you do not miss a release!"
 msgstr ""
 
-#: menus/menu-welcome.php:1063
+#: menus/menu-welcome.php:1068
 msgid "Get Alerted About New Tutorials"
 msgstr ""
 
-#: menus/menu-welcome.php:1064
+#: menus/menu-welcome.php:1069
 msgid ""
 "<a href=\"http://eepurl.com/TRO9f\" target=\"_blank\">Sign up now</a> to hear about "
 "the latest tutorial releases that explain how to take Easy Property Listings further."
 msgstr ""
 
-#: menus/menu-welcome.php:1068
+#: menus/menu-welcome.php:1073
 msgid "Extend With Extensions"
 msgstr ""
 
-#: menus/menu-welcome.php:1069
+#: menus/menu-welcome.php:1074
 msgid "18 Extensions and many more coming"
 msgstr ""
 
-#: menus/menu-welcome.php:1070
+#: menus/menu-welcome.php:1075
 msgid ""
 "Add-on plug ins are available that greatly extend the default functionality of Easy "
 "Property Listings. There are extensions for Listing Sliders, Brochures, Advanced "
@@ -4137,27 +4145,27 @@ msgid ""
 "Location Profiles, and many, many more."
 msgstr ""
 
-#: menus/menu-welcome.php:1072
+#: menus/menu-welcome.php:1077
 msgid "Visit the Extension Store"
 msgstr ""
 
-#: menus/menu-welcome.php:1073
+#: menus/menu-welcome.php:1078
 msgid "The Extensions store"
 msgstr ""
 
-#: menus/menu-welcome.php:1073
+#: menus/menu-welcome.php:1078
 msgid ""
 "has a list of all available extensions to make your real estate website even better."
 msgstr ""
 
-#: menus/menu-welcome.php:1098
+#: menus/menu-welcome.php:1103
 msgid ""
 "Easy Property Listings is created by a worldwide team of developers who aim to "
 "provide the #1 property listings platform for managing your real estate business "
 "through WordPress."
 msgstr ""
 
-#: menus/menu-welcome.php:1125
+#: menus/menu-welcome.php:1130
 #, php-format
 msgid "View %s"
 msgstr ""

--- a/lib/languages/epl.pot
+++ b/lib/languages/epl.pot
@@ -4,8 +4,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Easy Property Listings 2.2.5\n"
 "Report-Msgid-Bugs-To: http://wordpress.org/support/plugin/easy-property-listings\n"
-"POT-Creation-Date: 2015-08-20 00:16+0800\n"
-"PO-Revision-Date: 2015-08-20 00:16+0800\n"
+"POT-Creation-Date: 2015-08-20 00:58+0800\n"
+"PO-Revision-Date: 2015-08-20 00:58+0800\n"
 "Last-Translator: Merv Barrett <admin@realestateconnected.com.au>\n"
 "Language-Team: Real Estate Connected <admin@realestateconnected.com.au>\n"
 "Language: en\n"
@@ -505,46 +505,46 @@ msgstr ""
 msgid " Car Spaces"
 msgstr ""
 
-#: includes/functions.php:137 menus/menu-welcome.php:807
+#: includes/functions.php:137 menus/menu-welcome.php:810
 msgid "Property (Residential)"
 msgstr ""
 
 #: includes/functions.php:138 includes/functions.php:1146 includes/functions.php:1148
-#: includes/install.php:66 menus/menu-welcome.php:809 post-types/post-type-land.php:28
+#: includes/install.php:66 menus/menu-welcome.php:812 post-types/post-type-land.php:28
 #: post-types/post-type-land.php:29 post-types/post-type-land.php:30
 #: updates/epl-1.3.1.php:5 widgets/widget-admin-dashboard.php:56
 msgid "Land"
 msgstr ""
 
 #: includes/functions.php:139 includes/functions.php:1152 includes/functions.php:1154
-#: menus/menu-welcome.php:808 post-types/post-type-rental.php:29
+#: menus/menu-welcome.php:811 post-types/post-type-rental.php:29
 #: updates/epl-1.3.1.php:6 widgets/widget-admin-dashboard.php:59
 msgid "Rental"
 msgstr ""
 
 #: includes/functions.php:140 includes/functions.php:1158 includes/functions.php:1160
-#: includes/install.php:68 menus/menu-welcome.php:810 post-types/post-type-rural.php:28
+#: includes/install.php:68 menus/menu-welcome.php:813 post-types/post-type-rural.php:28
 #: post-types/post-type-rural.php:29 post-types/post-type-rural.php:30
 #: updates/epl-1.3.1.php:7 widgets/widget-admin-dashboard.php:62
 msgid "Rural"
 msgstr ""
 
 #: includes/functions.php:141 includes/functions.php:444 includes/functions.php:1164
-#: includes/functions.php:1166 includes/install.php:70 menus/menu-welcome.php:811
+#: includes/functions.php:1166 includes/install.php:70 menus/menu-welcome.php:814
 #: post-types/post-type-commercial.php:29 updates/epl-1.3.1.php:9
 #: widgets/widget-admin-dashboard.php:65
 msgid "Commercial"
 msgstr ""
 
 #: includes/functions.php:142 includes/functions.php:1170 includes/functions.php:1172
-#: includes/install.php:71 menus/menu-welcome.php:812
+#: includes/install.php:71 menus/menu-welcome.php:815
 #: post-types/post-type-commercial_land.php:30 updates/epl-1.3.1.php:10
 #: widgets/widget-admin-dashboard.php:68
 msgid "Commercial Land"
 msgstr ""
 
 #: includes/functions.php:143 includes/functions.php:1176 includes/functions.php:1178
-#: includes/install.php:69 menus/menu-welcome.php:813
+#: includes/install.php:69 menus/menu-welcome.php:816
 #: post-types/post-type-business.php:30 updates/epl-1.3.1.php:8
 #: widgets/widget-admin-dashboard.php:71
 msgid "Business"
@@ -1148,7 +1148,7 @@ msgid ""
 "grid options."
 msgstr ""
 
-#: includes/functions.php:1250 menus/menu-welcome.php:933
+#: includes/functions.php:1250 menus/menu-welcome.php:936
 msgid "Theme Compatibility"
 msgstr ""
 
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "What's New"
 msgstr ""
 
-#: menus/menu-help.php:36 menus/menu-welcome.php:269 menus/menu-welcome.php:787
+#: menus/menu-help.php:36 menus/menu-welcome.php:269 menus/menu-welcome.php:790
 msgid "Full Change Log"
 msgstr ""
 
@@ -1519,7 +1519,7 @@ msgstr ""
 msgid "Support the project"
 msgstr ""
 
-#: menus/menu-help.php:39 menus/menu-welcome.php:788
+#: menus/menu-help.php:39 menus/menu-welcome.php:791
 msgid "Visit Support"
 msgstr ""
 
@@ -1577,7 +1577,7 @@ msgstr ""
 msgid "The video will show you how to add a listing quickly and easily."
 msgstr ""
 
-#: menus/menu-help.php:112 menus/menu-welcome.php:860 widgets/widget-functions.php:12
+#: menus/menu-help.php:112 menus/menu-welcome.php:863 widgets/widget-functions.php:12
 #: widgets/widget-listing.php:270
 msgid "Title"
 msgstr ""
@@ -1621,7 +1621,7 @@ msgstr ""
 msgid "Listing Image Gallery"
 msgstr ""
 
-#: menus/menu-help.php:134 menus/menu-welcome.php:881
+#: menus/menu-help.php:134 menus/menu-welcome.php:884
 msgid "Add a gallery of images to your listings with the WordPress Add Media button."
 msgstr ""
 
@@ -1631,7 +1631,7 @@ msgid ""
 "media upload box once the images are attached to the listing."
 msgstr ""
 
-#: menus/menu-help.php:147 menus/menu-welcome.php:899 meta-boxes/meta-boxes.php:109
+#: menus/menu-help.php:147 menus/menu-welcome.php:902 meta-boxes/meta-boxes.php:109
 #: post-types/post-type-business.php:86 post-types/post-type-commercial.php:84
 #: post-types/post-type-commercial_land.php:85 post-types/post-type-land.php:85
 #: post-types/post-type-property.php:85 post-types/post-type-rental.php:84
@@ -1639,26 +1639,26 @@ msgstr ""
 msgid "Listing Details"
 msgstr ""
 
-#: menus/menu-help.php:149 menus/menu-welcome.php:905 meta-boxes/meta-boxes.php:121
+#: menus/menu-help.php:149 menus/menu-welcome.php:908 meta-boxes/meta-boxes.php:121
 msgid "Heading"
 msgstr ""
 
-#: menus/menu-help.php:150 menus/menu-welcome.php:906
+#: menus/menu-help.php:150 menus/menu-welcome.php:909
 msgid "Enter the descriptive listing headline like \"Great Property with Views\"."
 msgstr ""
 
-#: menus/menu-help.php:152 menus/menu-welcome.php:908 meta-boxes/meta-boxes.php:149
+#: menus/menu-help.php:152 menus/menu-welcome.php:911 meta-boxes/meta-boxes.php:149
 #: post-types/post-types.php:77
 msgid "Second Listing Agent"
 msgstr ""
 
-#: menus/menu-help.php:153 menus/menu-welcome.php:909
+#: menus/menu-help.php:153 menus/menu-welcome.php:912
 msgid ""
 "If the listing has two real estate agents marketing it, enter their WordPress user "
 "name here. The primary agent is the post Author."
 msgstr ""
 
-#: menus/menu-help.php:155 menus/menu-welcome.php:911
+#: menus/menu-help.php:155 menus/menu-welcome.php:914
 msgid "Inspection Times"
 msgstr ""
 
@@ -1709,19 +1709,19 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: menus/menu-welcome.php:157 menus/menu-welcome.php:761 menus/menu-welcome.php:1097
+#: menus/menu-welcome.php:157 menus/menu-welcome.php:764 menus/menu-welcome.php:1100
 #, php-format
 msgid "Welcome to Easy Property Listings %s"
 msgstr ""
 
-#: menus/menu-welcome.php:158 menus/menu-welcome.php:762 menus/menu-welcome.php:1098
+#: menus/menu-welcome.php:158 menus/menu-welcome.php:765 menus/menu-welcome.php:1101
 #, php-format
 msgid ""
 "Thank you for updating to the latest version! Easy Property Listings %s is ready to "
 "make your real estate website faster, safer and better!"
 msgstr ""
 
-#: menus/menu-welcome.php:159 menus/menu-welcome.php:763 menus/menu-welcome.php:1099
+#: menus/menu-welcome.php:159 menus/menu-welcome.php:766 menus/menu-welcome.php:1102
 #, php-format
 msgid "Version %s"
 msgstr ""
@@ -1940,500 +1940,512 @@ msgstr ""
 msgid "Fix: Widget construct fixes for WordPress 4.3."
 msgstr ""
 
+#: menus/menu-welcome.php:276
+msgid "Tweak: Un-install function."
+msgstr ""
+
+#: menus/menu-welcome.php:277
+msgid "Tweak: Plugin page link to settings."
+msgstr ""
+
 #: menus/menu-welcome.php:278
+msgid "Tweak: Languages updated."
+msgstr ""
+
+#: menus/menu-welcome.php:281
 msgid "Version 2.2.4"
 msgstr ""
 
-#: menus/menu-welcome.php:280
+#: menus/menu-welcome.php:283
 msgid ""
 "Tweak: Improvements to Commercial/Commercial Land/Business pricing when set to Lease "
 "type to display free form price text."
 msgstr ""
 
-#: menus/menu-welcome.php:281
+#: menus/menu-welcome.php:284
 msgid "Tweak: Bar graph in dashboard will no longer cover address if set to low."
 msgstr ""
 
-#: menus/menu-welcome.php:282
+#: menus/menu-welcome.php:285
 msgid "Tweak: Added sticker CSS styling for single listing."
 msgstr ""
 
-#: menus/menu-welcome.php:283
+#: menus/menu-welcome.php:286
 msgid "Fix: Search Widget/Shortcode display house category value instead of key."
 msgstr ""
 
-#: menus/menu-welcome.php:284
+#: menus/menu-welcome.php:287
 msgid "Fix: Search Widget/Shortcode Property ID correctly searches numeric listing ID."
 msgstr ""
 
-#: menus/menu-welcome.php:285
+#: menus/menu-welcome.php:288
 msgid ""
 "Fix: Search Widget/Shortcode excluded non searchable fields from land, commercial, "
 "commercial land and business post types."
 msgstr ""
 
-#: menus/menu-welcome.php:288
+#: menus/menu-welcome.php:291
 msgid "Version 2.2.3"
 msgstr ""
 
-#: menus/menu-welcome.php:290
+#: menus/menu-welcome.php:293
 msgid "Tweak: Adjusted new sorter function to work on lower than PHP version 5.3."
 msgstr ""
 
-#: menus/menu-welcome.php:291
+#: menus/menu-welcome.php:294
 msgid ""
 "Tweak: Moved old template functions to theme compatibility, will be removed in future "
 "version."
 msgstr ""
 
-#: menus/menu-welcome.php:292
+#: menus/menu-welcome.php:295
 msgid ""
 "Tweak: Set sorter list style to none to prevent some themes from displaying a list "
 "bullet."
 msgstr ""
 
-#: menus/menu-welcome.php:295
+#: menus/menu-welcome.php:298
 msgid "Version 2.2.2"
 msgstr ""
 
-#: menus/menu-welcome.php:297
+#: menus/menu-welcome.php:300
 msgid "Tweak: CSS tweak for image size to retain proportion on some themes."
 msgstr ""
 
-#: menus/menu-welcome.php:298
+#: menus/menu-welcome.php:301
 msgid ""
 "Tweak: Adjusted position of show/hide suburb on Commercial/Business listing types."
 msgstr ""
 
-#: menus/menu-welcome.php:299
+#: menus/menu-welcome.php:302
 msgid "Fix: Archive image correctly loading 300x200 image."
 msgstr ""
 
-#: menus/menu-welcome.php:300
+#: menus/menu-welcome.php:303
 msgid "Fix: Listing address display settings fixed."
 msgstr ""
 
-#: menus/menu-welcome.php:303
+#: menus/menu-welcome.php:306
 msgid "Version 2.2.1"
 msgstr ""
 
-#: menus/menu-welcome.php:305
+#: menus/menu-welcome.php:308
 msgid "Tweak: Set padding for search tabs for better display on some themes."
 msgstr ""
 
-#: menus/menu-welcome.php:306
+#: menus/menu-welcome.php:309
 msgid "Fix: Search function fix checking for empty option when using custom filters."
 msgstr ""
 
-#: menus/menu-welcome.php:309
+#: menus/menu-welcome.php:312
 msgid "Version 2.2"
 msgstr ""
 
-#: menus/menu-welcome.php:311
+#: menus/menu-welcome.php:314
 msgid ""
 "New: Search shortcode and widget rebuilt to enable adding additional fields through "
 "filters and hooks."
 msgstr ""
 
-#: menus/menu-welcome.php:312
+#: menus/menu-welcome.php:315
 msgid ""
 "New: Search shortcode and widget added additional search fields for City, State, "
 "Postcode and Country."
 msgstr ""
 
-#: menus/menu-welcome.php:313
+#: menus/menu-welcome.php:316
 msgid ""
 "New: Search shortcode and widget allows for optional multi select of house category."
 msgstr ""
 
-#: menus/menu-welcome.php:314
+#: menus/menu-welcome.php:317
 msgid "New: Search shortcode and widget improved responsive CSS."
 msgstr ""
 
-#: menus/menu-welcome.php:315
+#: menus/menu-welcome.php:318
 msgid "New: Grid styles included in main CSS for use in extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:316
+#: menus/menu-welcome.php:319
 msgid ""
 "New: Upload button added for use in custom plug-ins and extensions to upload files."
 msgstr ""
 
-#: menus/menu-welcome.php:317
+#: menus/menu-welcome.php:320
 msgid "New: Filter to adjust tour labels."
 msgstr ""
 
-#: menus/menu-welcome.php:318
+#: menus/menu-welcome.php:321
 msgid "New: Filters to adjust Floor Plan labels."
 msgstr ""
 
-#: menus/menu-welcome.php:319
+#: menus/menu-welcome.php:322
 msgid "New: Filters to adjust External Link labels."
 msgstr ""
 
-#: menus/menu-welcome.php:320
+#: menus/menu-welcome.php:323
 msgid "New: Sold prices now display when set on front end and manage listings pages."
 msgstr ""
 
-#: menus/menu-welcome.php:321
+#: menus/menu-welcome.php:324
 msgid "New: Label function for returning meta labels."
 msgstr ""
 
-#: menus/menu-welcome.php:322
+#: menus/menu-welcome.php:325
 msgid ""
 "New: Ads on settings no longer display when there is an activated extension present."
 msgstr ""
 
-#: menus/menu-welcome.php:323
+#: menus/menu-welcome.php:326
 msgid "New: Locked and help cases options for use in extensions and custom plugins."
 msgstr ""
 
-#: menus/menu-welcome.php:324
+#: menus/menu-welcome.php:327
 msgid ""
 "New: Theme compatibility mode which enables all themes to display correctly with "
 "options to disable featured images for themes that automatically add featured images."
 msgstr ""
 
-#: menus/menu-welcome.php:325
+#: menus/menu-welcome.php:328
 msgid ""
 "New: City setting to allow addresses in countries that need more than a suburb Label "
 "is customisable from settings."
 msgstr ""
 
-#: menus/menu-welcome.php:326
+#: menus/menu-welcome.php:329
 msgid "New: Country setting to allow the country to display with the listing address."
 msgstr ""
 
-#: menus/menu-welcome.php:327
+#: menus/menu-welcome.php:330
 msgid "New: Able to adjust or add more registered thumbnail sizes through a filter."
 msgstr ""
 
-#: menus/menu-welcome.php:328
+#: menus/menu-welcome.php:331
 msgid "New: Function to get all the values associated with a specific post meta key."
 msgstr ""
 
-#: menus/menu-welcome.php:329
+#: menus/menu-welcome.php:332
 msgid ""
 "New: Replaced the_post_thumbnail on archive pages and shortcodes with a customisable "
 "hook allowing for additional customisation with themes."
 msgstr ""
 
-#: menus/menu-welcome.php:330
+#: menus/menu-welcome.php:333
 msgid ""
 "New: Specific templates for theme compatibility mode for archive and single listings."
 msgstr ""
 
-#: menus/menu-welcome.php:331
+#: menus/menu-welcome.php:334
 msgid ""
 "New: Template loading system allowing for additional templates to be added to "
 "shortcodes and widgets from themes, custom plug-ins and extensions. This allows you "
 "to create an unlimited number of templates and load them from your theme."
 msgstr ""
 
-#: menus/menu-welcome.php:332
+#: menus/menu-welcome.php:335
 msgid "New: Sorter allows for sorting by current/sold leased."
 msgstr ""
 
-#: menus/menu-welcome.php:333
+#: menus/menu-welcome.php:336
 msgid "New: Ability to add additional sorter via filter."
 msgstr ""
 
-#: menus/menu-welcome.php:334
+#: menus/menu-welcome.php:337
 msgid "New: Post counter function for use in extensions and custom plug-ins."
 msgstr ""
 
-#: menus/menu-welcome.php:335
+#: menus/menu-welcome.php:338
 msgid "New: User fields re-built which allows for adding on new fields through filter."
 msgstr ""
 
-#: menus/menu-welcome.php:336
+#: menus/menu-welcome.php:339
 msgid "New: Help meta type allowing for better internal documentation in extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:337
+#: menus/menu-welcome.php:340
 msgid "New: City meta field added to all listing types when enabled."
 msgstr ""
 
-#: menus/menu-welcome.php:338
+#: menus/menu-welcome.php:341
 msgid "New: Rental display or hide rental price."
 msgstr ""
 
-#: menus/menu-welcome.php:339
+#: menus/menu-welcome.php:342
 msgid "New: Check-box single field type."
 msgstr ""
 
-#: menus/menu-welcome.php:340
+#: menus/menu-welcome.php:343
 msgid ""
 "New: Actions added to enable extensions to better hook into listings types and "
 "optimised functions for admin column details."
 msgstr ""
 
-#: menus/menu-welcome.php:341
+#: menus/menu-welcome.php:344
 msgid "New: Dashboard widget now displays other extensions content counts."
 msgstr ""
 
-#: menus/menu-welcome.php:342
+#: menus/menu-welcome.php:345
 msgid ""
 "New: Listing widget now allows for additional selectable templates to be added "
 "through custom plug-ins, hooks and themes."
 msgstr ""
 
-#: menus/menu-welcome.php:343
+#: menus/menu-welcome.php:346
 msgid "New: Replaced widget image with a dynamic action."
 msgstr ""
 
-#: menus/menu-welcome.php:344
+#: menus/menu-welcome.php:347
 msgid "New: Filter added for Gravatar image."
 msgstr ""
 
-#: menus/menu-welcome.php:345
+#: menus/menu-welcome.php:348
 msgid "New: Replaced widget and author box image functions with actions."
 msgstr ""
 
-#: menus/menu-welcome.php:346
+#: menus/menu-welcome.php:349
 msgid "New: Uninstall function to remove all Easy Property Listings content."
 msgstr ""
 
-#: menus/menu-welcome.php:347
+#: menus/menu-welcome.php:350
 msgid "New: Get option function."
 msgstr ""
 
-#: menus/menu-welcome.php:348
+#: menus/menu-welcome.php:351
 msgid ""
 "New: When saving settings on extensions sub tabs you are no longer taken to the first "
 "tab."
 msgstr ""
 
-#: menus/menu-welcome.php:349
+#: menus/menu-welcome.php:352
 msgid "New: Customisable state label."
 msgstr ""
 
-#: menus/menu-welcome.php:350
+#: menus/menu-welcome.php:353
 msgid "Tweak: Improved under offer, sold and leased labels."
 msgstr ""
 
-#: menus/menu-welcome.php:351
+#: menus/menu-welcome.php:354
 msgid ""
 "Tweak: Improved install function to reduce code and allow for new settings to be "
 "added."
 msgstr ""
 
-#: menus/menu-welcome.php:352
+#: menus/menu-welcome.php:355
 msgid "Tweak: Removed redundant code and streamlined templates."
 msgstr ""
 
-#: menus/menu-welcome.php:353
+#: menus/menu-welcome.php:356
 msgid "Tweak: Improved reset query function."
 msgstr ""
 
-#: menus/menu-welcome.php:354
+#: menus/menu-welcome.php:357
 msgid "Tweak: Removed old functions improving plugin code."
 msgstr ""
 
-#: menus/menu-welcome.php:355
+#: menus/menu-welcome.php:358
 msgid "Tweak: Rebuilt address function to allow for city and country."
 msgstr ""
 
-#: menus/menu-welcome.php:356
+#: menus/menu-welcome.php:359
 msgid "Tweak: Improved sorter function in all shortcodes."
 msgstr ""
 
-#: menus/menu-welcome.php:357
+#: menus/menu-welcome.php:360
 msgid ""
 "Tweak: Improvements to Commercial and Business listing types to better comply with "
 "REAXML format with business takings, franchise, terms and commercial outgoings."
 msgstr ""
 
-#: menus/menu-welcome.php:358
+#: menus/menu-welcome.php:361
 msgid "Tweak: Reorganised settings page."
 msgstr ""
 
-#: menus/menu-welcome.php:359
+#: menus/menu-welcome.php:362
 msgid "Tweak: Translations updated and additional tags added."
 msgstr ""
 
-#: menus/menu-welcome.php:360
+#: menus/menu-welcome.php:363
 msgid ""
 "Tweak: Search button default label changed from \"Find Me A Property!\" to \"Search\"."
 msgstr ""
 
-#: menus/menu-welcome.php:361
+#: menus/menu-welcome.php:364
 msgid "Tweak: Applied custom suburb label to EPL - Listing Widget."
 msgstr ""
 
-#: menus/menu-welcome.php:362
+#: menus/menu-welcome.php:365
 msgid "Fix: Listings house categories correctly display labels instead of values."
 msgstr ""
 
-#: menus/menu-welcome.php:363
+#: menus/menu-welcome.php:366
 msgid "Fix: Listings with carport, garage or values set to zero no longer display."
 msgstr ""
 
-#: menus/menu-welcome.php:364
+#: menus/menu-welcome.php:367
 msgid "Fix: Shortcode compatibility for WordPress 3.3 thanks to codewp"
 msgstr ""
 
-#: menus/menu-welcome.php:365
+#: menus/menu-welcome.php:368
 msgid "Fix: Saving listing when in debug mode and ticking hide map or hide author box."
 msgstr ""
 
-#: menus/menu-welcome.php:366
+#: menus/menu-welcome.php:369
 msgid "Fix: New Zealand currency now displays a dollar sign."
 msgstr ""
 
-#: menus/menu-welcome.php:369
+#: menus/menu-welcome.php:372
 msgid "Version 2.1.11"
 msgstr ""
 
-#: menus/menu-welcome.php:372
+#: menus/menu-welcome.php:375
 msgid ""
 "Tweak: Removed sub titles \"Property Manager\" and \"Real Estate Agent\" from the "
 "single listing template for better language support and to facilitate the hiding of "
 "the author box."
 msgstr ""
 
-#: menus/menu-welcome.php:373
+#: menus/menu-welcome.php:376
 msgid "Tweak: Added epl- prefix to all author-box and widget css."
 msgstr ""
 
-#: menus/menu-welcome.php:374
+#: menus/menu-welcome.php:377
 msgid ""
 "Tweak: Renamed author-box container with epl-author-box-container as it was harder to "
 "target the author box content and adjusted JS for tabs."
 msgstr ""
 
-#: menus/menu-welcome.php:375
+#: menus/menu-welcome.php:378
 msgid "Tweak: Improved author box responsive CSS."
 msgstr ""
 
-#: menus/menu-welcome.php:376
+#: menus/menu-welcome.php:379
 msgid "Tweak: Updated extension updater for multisite and other improvements."
 msgstr ""
 
-#: menus/menu-welcome.php:377
+#: menus/menu-welcome.php:380
 msgid "Tweak: Leased label when adding a property will use custom label."
 msgstr ""
 
-#: menus/menu-welcome.php:378
+#: menus/menu-welcome.php:381
 msgid "Tweak: Wrapper class for property category."
 msgstr ""
 
-#: menus/menu-welcome.php:379
+#: menus/menu-welcome.php:382
 msgid "Fix: Undefined status if importing listings not using current status."
 msgstr ""
 
-#: menus/menu-welcome.php:380
+#: menus/menu-welcome.php:383
 msgid ""
 "Fix: When user selects grid/list option and pages the user selected view is retained."
 msgstr ""
 
-#: menus/menu-welcome.php:381
+#: menus/menu-welcome.php:384
 msgid "Fix: [listing post_type=\"rental\"] shortcode price sorting for rental."
 msgstr ""
 
-#: menus/menu-welcome.php:382
+#: menus/menu-welcome.php:385
 msgid "New: Author box is now able to be hidden on a per listing basis."
 msgstr ""
 
-#: menus/menu-welcome.php:383
+#: menus/menu-welcome.php:386
 msgid "New: Added filters for author box social links."
 msgstr ""
 
-#: menus/menu-welcome.php:384
+#: menus/menu-welcome.php:387
 msgid "New: Inspection filter to adjust the inspection date/time format."
 msgstr ""
 
-#: menus/menu-welcome.php:385
+#: menus/menu-welcome.php:388
 msgid ""
 "New: Several author widget filters added to enable additional content through "
 "extensions or custom functions."
 msgstr ""
 
-#: menus/menu-welcome.php:386
+#: menus/menu-welcome.php:389
 msgid ""
 "New: Sold, leased, under offer label filter which uses the label setting and label "
 "changes dashboard widget, admin category filters and search widget."
 msgstr ""
 
-#: menus/menu-welcome.php:387
+#: menus/menu-welcome.php:390
 msgid "New: Sold label making Sold STC possible or other Sold label variant."
 msgstr ""
 
-#: menus/menu-welcome.php:388
+#: menus/menu-welcome.php:391
 msgid "New: Danish language thanks to pascal."
 msgstr ""
 
-#: menus/menu-welcome.php:389
+#: menus/menu-welcome.php:392
 msgid "New: German language thanks to ChriKn."
 msgstr ""
 
-#: menus/menu-welcome.php:390
+#: menus/menu-welcome.php:393
 msgid "New: Ukrainian language thanks to Alex."
 msgstr ""
 
-#: menus/menu-welcome.php:391
+#: menus/menu-welcome.php:394
 msgid "New: Swedish language thanks to Roland J."
 msgstr ""
 
-#: menus/menu-welcome.php:394
+#: menus/menu-welcome.php:397
 msgid "Version 2.1.10"
 msgstr ""
 
-#: menus/menu-welcome.php:397
+#: menus/menu-welcome.php:400
 msgid "New: Email field validation added."
 msgstr ""
 
-#: menus/menu-welcome.php:398
+#: menus/menu-welcome.php:401
 msgid "New: Added status classes to widgets for better targeting of CSS styles."
 msgstr ""
 
-#: menus/menu-welcome.php:399
+#: menus/menu-welcome.php:402
 msgid "Tweak: Improved video embed and added a filter to adjust video container size."
 msgstr ""
 
-#: menus/menu-welcome.php:400
+#: menus/menu-welcome.php:403
 msgid ""
 "Tweak: Improved CSS wrappers for listing widget and added dynamic class depending on "
 "widget display style."
 msgstr ""
 
-#: menus/menu-welcome.php:401
+#: menus/menu-welcome.php:404
 msgid "Tweak: Added additional classes to Listing Widget list variant style list items."
 msgstr ""
 
-#: menus/menu-welcome.php:402
+#: menus/menu-welcome.php:405
 msgid "Fix: Additional paging issues fixed in listing widget for other options."
 msgstr ""
 
-#: menus/menu-welcome.php:403
+#: menus/menu-welcome.php:406
 msgid "Fix: Widget leased selection displays rentals correctly."
 msgstr ""
 
-#: menus/menu-welcome.php:406
+#: menus/menu-welcome.php:409
 msgid "Version 2.1.9"
 msgstr ""
 
-#: menus/menu-welcome.php:409
+#: menus/menu-welcome.php:412
 msgid "Fix: Fixed paging issues in listing widget."
 msgstr ""
 
-#: menus/menu-welcome.php:410
+#: menus/menu-welcome.php:413
 msgid "Fix: Fix shortcodes when using multiple listing post types."
 msgstr ""
 
-#: menus/menu-welcome.php:413
+#: menus/menu-welcome.php:416
 msgid "Version 2.1.8"
 msgstr ""
 
-#: menus/menu-welcome.php:416
+#: menus/menu-welcome.php:419
 msgid "New: Ability to disable all plugin CSS from Advanced Settings section."
 msgstr ""
 
-#: menus/menu-welcome.php:417
+#: menus/menu-welcome.php:420
 msgid "New: Search widget and shortcode now have the option to turn of Location search."
 msgstr ""
 
-#: menus/menu-welcome.php:418
+#: menus/menu-welcome.php:421
 msgid ""
 "New: Search widget and shortcode now have filters to control the display of \"Any\". "
 "Each field has a unique filter which will allow you to hide the label using CSS and "
@@ -2441,15 +2453,15 @@ msgid ""
 "create super slim search boxes."
 msgstr ""
 
-#: menus/menu-welcome.php:419
+#: menus/menu-welcome.php:422
 msgid "New: Added translation Belgian (Dutch) thanks to pascal.beyens"
 msgstr ""
 
-#: menus/menu-welcome.php:420
+#: menus/menu-welcome.php:423
 msgid "New: Polish translation thanks to Weronika.urbanczyk"
 msgstr ""
 
-#: menus/menu-welcome.php:421
+#: menus/menu-welcome.php:424
 msgid ""
 "New: Two mew shortcode templates table and table_open usable with shortcodes to "
 "provide a slim list of listings. Example usage is [listing_open template=\"table\"] "
@@ -2457,310 +2469,310 @@ msgid ""
 "theme/easypropertylistings folder to further customize."
 msgstr ""
 
-#: menus/menu-welcome.php:422
+#: menus/menu-welcome.php:425
 msgid ""
 "New: Added currency support for Qatar Riyal (QAR), United Arab Emirates (AED), "
 "Ukrainian Hryvnia (UAH), Vietnamese đồng (VND)"
 msgstr ""
 
-#: menus/menu-welcome.php:423
+#: menus/menu-welcome.php:426
 msgid "New: checkbox_single ability for plugin and extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:424
+#: menus/menu-welcome.php:427
 msgid "New: Ability to disable map on each listing."
 msgstr ""
 
-#: menus/menu-welcome.php:425
+#: menus/menu-welcome.php:428
 msgid ""
 "Tweak: Updated currency symbols for: Israeli Shekel, Thai Baht, Indian Rupee, Turkish "
 "Lira, Iranian Rial."
 msgstr ""
 
-#: menus/menu-welcome.php:426
+#: menus/menu-welcome.php:429
 msgid ""
 "Tweak: Improved CSS and added additional classes with epl- prefix in templates and "
 "search."
 msgstr ""
 
-#: menus/menu-welcome.php:427
+#: menus/menu-welcome.php:430
 msgid "Tweak: Improved CSS for Location Profiles and Staff Directory extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:428
+#: menus/menu-welcome.php:431
 msgid ""
 "Tweak: Added filters for commercial titles to allow you to change \"For Lease\" and "
 "\"For Sale\" using epl_commercial_for_lease_label, and epl_commercial_for_sale_label "
 "filters."
 msgstr ""
 
-#: menus/menu-welcome.php:429
+#: menus/menu-welcome.php:432
 msgid "Tweak: Additional CSS classes for Land, Commercial and Rural special features."
 msgstr ""
 
-#: menus/menu-welcome.php:430
+#: menus/menu-welcome.php:433
 msgid "Tweak: Gallery CSS classes added."
 msgstr ""
 
-#: menus/menu-welcome.php:431
+#: menus/menu-welcome.php:434
 msgid ""
 "Tweak: Improved table shortcodes CSS and styling for better full display and "
 "responsive widths."
 msgstr ""
 
-#: menus/menu-welcome.php:432
+#: menus/menu-welcome.php:435
 msgid "Fix: New/Open Sticker now appear on listings with the price display set to no."
 msgstr ""
 
-#: menus/menu-welcome.php:433
+#: menus/menu-welcome.php:436
 msgid "Fix: Translations work correctly for categories."
 msgstr ""
 
-#: menus/menu-welcome.php:436
+#: menus/menu-welcome.php:439
 msgid "Version 2.1.7"
 msgstr ""
 
-#: menus/menu-welcome.php:439
+#: menus/menu-welcome.php:442
 msgid ""
 "New: listing_search shortcode now has style option for adjusting the width. You can "
 "add style=\"slim\" or style=\"wide\" to the shortcode to adjust the appearance."
 msgstr ""
 
-#: menus/menu-welcome.php:440
+#: menus/menu-welcome.php:443
 msgid "New: Listing Search widget now has style options for adjusting the width."
 msgstr ""
 
-#: menus/menu-welcome.php:441
+#: menus/menu-welcome.php:444
 msgid "Tweak: Updated translation and added missing sqm translation element."
 msgstr ""
 
-#: menus/menu-welcome.php:442
+#: menus/menu-welcome.php:445
 msgid "Tweak: Allowed for hundredths decimal in bathrooms field."
 msgstr ""
 
-#: menus/menu-welcome.php:443
+#: menus/menu-welcome.php:446
 msgid "Tweak: Floor plan button CSS."
 msgstr ""
 
-#: menus/menu-welcome.php:444
+#: menus/menu-welcome.php:447
 msgid "Tweak: Address and price responsive CSS."
 msgstr ""
 
-#: menus/menu-welcome.php:445
+#: menus/menu-welcome.php:448
 msgid "Fix: Auction listing price set to no displays auction date correctly."
 msgstr ""
 
-#: menus/menu-welcome.php:446
+#: menus/menu-welcome.php:449
 msgid "Fix: Fix: Author position css class."
 msgstr ""
 
-#: menus/menu-welcome.php:449
+#: menus/menu-welcome.php:452
 msgid "Version 2.1.6"
 msgstr ""
 
-#: menus/menu-welcome.php:452
+#: menus/menu-welcome.php:455
 msgid "Fix: Fancy pagination paging works correctly when shortcodes used on home page."
 msgstr ""
 
-#: menus/menu-welcome.php:453
+#: menus/menu-welcome.php:456
 msgid "Fix: Wrapped new pagination feature in esc_url to prevent vulnerability."
 msgstr ""
 
-#: menus/menu-welcome.php:454
+#: menus/menu-welcome.php:457
 msgid ""
 "Fix: Corrected sorting by price when using shortcodes. Note: Rental sorting works on "
 "post_type=\"rental\" in all shortcodes."
 msgstr ""
 
-#: menus/menu-welcome.php:455
+#: menus/menu-welcome.php:458
 msgid ""
 "Tweak: Added rental rate view for text entry of rental rates for REAXML compatibility."
 msgstr ""
 
-#: menus/menu-welcome.php:456
+#: menus/menu-welcome.php:459
 msgid ""
 "Tweak: Corrected admin display columns and edit listing pages for better display on "
 "mobile devices."
 msgstr ""
 
-#: menus/menu-welcome.php:459
+#: menus/menu-welcome.php:462
 msgid "Version 2.1.5"
 msgstr ""
 
-#: menus/menu-welcome.php:462
+#: menus/menu-welcome.php:465
 msgid ""
 "Tweak: Commercial listing: Ability to set commercial lease rate to a decimal value "
 "using the epl_price_number_format_commercial_lease filter."
 msgstr ""
 
-#: menus/menu-welcome.php:463
+#: menus/menu-welcome.php:466
 msgid "Tweak: Updated epl.pot translation file."
 msgstr ""
 
-#: menus/menu-welcome.php:464
+#: menus/menu-welcome.php:467
 msgid ""
 "Tweak: Removed horizontal line elements in the help section to match WordPress 4.2 "
 "admin page styles."
 msgstr ""
 
-#: menus/menu-welcome.php:465
+#: menus/menu-welcome.php:468
 msgid ""
 "Tweak: Rental Listing: Added epl_property_bond_position filter to adjust the position "
 "of the Bond/Deposit to appear either before or after the value."
 msgstr ""
 
-#: menus/menu-welcome.php:466
+#: menus/menu-welcome.php:469
 msgid "Tweak: Rental Listing: Removed CSS padding before bond value."
 msgstr ""
 
-#: menus/menu-welcome.php:467
+#: menus/menu-welcome.php:470
 msgid ""
 "Fix: Rental Listing: Adjusting the Bond/Deposit label will now show your custom label "
 "in the Rental Price box."
 msgstr ""
 
-#: menus/menu-welcome.php:468
+#: menus/menu-welcome.php:471
 msgid "Fix: Rural Listing: Undefined label_leased variable."
 msgstr ""
 
-#: menus/menu-welcome.php:469
+#: menus/menu-welcome.php:472
 msgid ""
 "Note: Confirmed Easy Property Listings is not vulnerable to recent WordPress exploit."
 msgstr ""
 
-#: menus/menu-welcome.php:470
+#: menus/menu-welcome.php:473
 msgid "New: Added setting to show/hide Listing Unique ID column when managing listings."
 msgstr ""
 
-#: menus/menu-welcome.php:473
+#: menus/menu-welcome.php:476
 msgid "Version 2.1.4"
 msgstr ""
 
-#: menus/menu-welcome.php:476
+#: menus/menu-welcome.php:479
 msgid "Tweak: Pagination optimised and no longer loads in admin."
 msgstr ""
 
-#: menus/menu-welcome.php:477
+#: menus/menu-welcome.php:480
 msgid "Tweak: New filter epl_price_number_format added for decimal rental rates."
 msgstr ""
 
-#: menus/menu-welcome.php:478
+#: menus/menu-welcome.php:481
 msgid "Fix: Display custom bond label when viewing listings."
 msgstr ""
 
-#: menus/menu-welcome.php:479
+#: menus/menu-welcome.php:482
 msgid ""
 "Tweak: Added filter epl_floorplan_button_label_filter to adjust Floor Plan button "
 "label."
 msgstr ""
 
-#: menus/menu-welcome.php:482
+#: menus/menu-welcome.php:485
 msgid "Version 2.1.3"
 msgstr ""
 
-#: menus/menu-welcome.php:485
+#: menus/menu-welcome.php:488
 msgid ""
 "Fix: Author box upgraded to allow for custom tabs and better extension integration "
 "with author box and widget."
 msgstr ""
 
-#: menus/menu-welcome.php:486
+#: menus/menu-welcome.php:489
 msgid "Fix: Added additional epl-author-archive CSS class for author archive pages."
 msgstr ""
 
-#: menus/menu-welcome.php:487
+#: menus/menu-welcome.php:490
 msgid "Fix: Improved CSS classes for author box with better responsive support."
 msgstr ""
 
-#: menus/menu-welcome.php:488
+#: menus/menu-welcome.php:491
 msgid "Fix: Added additional filters for author contact information."
 msgstr ""
 
-#: menus/menu-welcome.php:489
+#: menus/menu-welcome.php:492
 msgid ""
 "Fix: Added secondary global author function for simpler integration for extensions "
 "like the Staff Directory."
 msgstr ""
 
-#: menus/menu-welcome.php:490
+#: menus/menu-welcome.php:493
 msgid "Fix: Changes to author tempaltes and restored author position variable."
 msgstr ""
 
-#: menus/menu-welcome.php:491
+#: menus/menu-welcome.php:494
 msgid "Fix: Further improved max and min graph values when in listing admin."
 msgstr ""
 
-#: menus/menu-welcome.php:494
+#: menus/menu-welcome.php:497
 msgid "Version 2.1.2"
 msgstr ""
 
-#: menus/menu-welcome.php:496
+#: menus/menu-welcome.php:499
 msgid "Fix: Improved Responsive CSS for grid style."
 msgstr ""
 
-#: menus/menu-welcome.php:497
+#: menus/menu-welcome.php:500
 msgid ""
 "Fix: Twenty Fifteen, Twenty Fourteen, Twenty Thirteen, Twenty Twelve CSS styles for "
 "better display."
 msgstr ""
 
-#: menus/menu-welcome.php:498
+#: menus/menu-welcome.php:501
 msgid "New: Added CSS class theme name output to archive and single templates."
 msgstr ""
 
-#: menus/menu-welcome.php:501
+#: menus/menu-welcome.php:504
 msgid "Version 2.1.1"
 msgstr ""
 
-#: menus/menu-welcome.php:503
+#: menus/menu-welcome.php:506
 msgid ""
 "Fix: Max price defaults set for graph calculations when upgrading from pre 2.0 "
 "version."
 msgstr ""
 
-#: menus/menu-welcome.php:506
+#: menus/menu-welcome.php:509
 msgid "Version 2.1"
 msgstr ""
 
-#: menus/menu-welcome.php:508
+#: menus/menu-welcome.php:511
 msgid "New: Fancy pagination option which can be enabled in settings."
 msgstr ""
 
-#: menus/menu-welcome.php:509
+#: menus/menu-welcome.php:512
 msgid "New: Coordinates now added to listing if not set prior."
 msgstr ""
 
-#: menus/menu-welcome.php:510
+#: menus/menu-welcome.php:513
 msgid "New: Ability to select larger listing image sizes in admin."
 msgstr ""
 
-#: menus/menu-welcome.php:511
+#: menus/menu-welcome.php:514
 msgid "New: Added date picker for available date on rental listing."
 msgstr ""
 
-#: menus/menu-welcome.php:512
+#: menus/menu-welcome.php:515
 msgid "New: Added date picker for sold date."
 msgstr ""
 
-#: menus/menu-welcome.php:513
+#: menus/menu-welcome.php:516
 msgid ""
 "New: New function that combines all meta box options into one global function for "
 "admin pages."
 msgstr ""
 
-#: menus/menu-welcome.php:514
+#: menus/menu-welcome.php:517
 msgid "New: Display second agent name in admin listing lists."
 msgstr ""
 
-#: menus/menu-welcome.php:515
+#: menus/menu-welcome.php:518
 msgid "New: Additional admin option to filter by agent/author. "
 msgstr ""
 
-#: menus/menu-welcome.php:516
+#: menus/menu-welcome.php:519
 msgid "New: Shortcode [listing_location] to display listings by specific location."
 msgstr ""
 
-#: menus/menu-welcome.php:517
+#: menus/menu-welcome.php:520
 msgid ""
 "New: The following shortcodes can now be filtered by location taxonomy: [listing "
 "location=\"perth\"], [listing_open location=\"sydney\"], [listing_category location="
@@ -2768,485 +2780,485 @@ msgid ""
 "\"terrace\" location=\"new-york\"]"
 msgstr ""
 
-#: menus/menu-welcome.php:518
+#: menus/menu-welcome.php:521
 msgid ""
 "New: The following shortcodes can now be sorted by price, date and ordered by ASC and "
 "DESC [listing sortby=\"price\" sort_order=\"ASC\"]."
 msgstr ""
 
-#: menus/menu-welcome.php:519
+#: menus/menu-welcome.php:522
 msgid ""
 "New: Sorter added to shortcodes which can be enabled by adding tools_top=\"on\" to "
 "your shortcode options."
 msgstr ""
 
-#: menus/menu-welcome.php:520
+#: menus/menu-welcome.php:523
 msgid "New: Template added in table format for use in shortcodes template=\"table\"."
 msgstr ""
 
-#: menus/menu-welcome.php:521
+#: menus/menu-welcome.php:524
 msgid "New: Function to get all active post types."
 msgstr ""
 
-#: menus/menu-welcome.php:522
+#: menus/menu-welcome.php:525
 msgid "New: Ability to register additional custom post types."
 msgstr ""
 
-#: menus/menu-welcome.php:523
+#: menus/menu-welcome.php:526
 msgid "New: Extensions now have additional help text ability."
 msgstr ""
 
-#: menus/menu-welcome.php:524
+#: menus/menu-welcome.php:527
 msgid "New: All menus now use global function to render fields."
 msgstr ""
 
-#: menus/menu-welcome.php:525
+#: menus/menu-welcome.php:528
 msgid ""
 "New: Improved template output and added additional CSS wrappers for some theme and "
 "HTML5 themes."
 msgstr ""
 
-#: menus/menu-welcome.php:526
+#: menus/menu-welcome.php:529
 msgid "New: Commercial rental lease duration now selectable."
 msgstr ""
 
-#: menus/menu-welcome.php:527
+#: menus/menu-welcome.php:530
 msgid "New: Rooms field added to set the number of rooms that the listing has."
 msgstr ""
 
-#: menus/menu-welcome.php:528
+#: menus/menu-welcome.php:531
 msgid "New: Date listed field added to all listing types."
 msgstr ""
 
-#: menus/menu-welcome.php:529
+#: menus/menu-welcome.php:532
 msgid "New: Year built field added to property, rental, rural listing types."
 msgstr ""
 
-#: menus/menu-welcome.php:530
+#: menus/menu-welcome.php:533
 msgid "New: Media upload function for use in extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:531
+#: menus/menu-welcome.php:534
 msgid "New: Ability to customise Under Offer and Leased labels in settings."
 msgstr ""
 
-#: menus/menu-welcome.php:532
+#: menus/menu-welcome.php:535
 msgid ""
 "New: Lease type label loaded from dropdown select. So you can have NNN, P.A., Full "
 "Service, Gross Lease Rates, on commercial listing types. Also has a filter to enable "
 "customisation of the options."
 msgstr ""
 
-#: menus/menu-welcome.php:533
+#: menus/menu-welcome.php:536
 msgid "New: Disable links in the feature list."
 msgstr ""
 
-#: menus/menu-welcome.php:534
+#: menus/menu-welcome.php:537
 msgid "Fix: Text domain fixes on template files."
 msgstr ""
 
-#: menus/menu-welcome.php:535
+#: menus/menu-welcome.php:538
 msgid "Fix: Finnish translation file renamed."
 msgstr ""
 
-#: menus/menu-welcome.php:536
+#: menus/menu-welcome.php:539
 msgid "Fix: FeedSync date processor strptime function corrected."
 msgstr ""
 
-#: menus/menu-welcome.php:537
+#: menus/menu-welcome.php:540
 msgid ""
 "Fix: Bug in parking search field. Was only searching carports and not garages. Now "
 "searches both."
 msgstr ""
 
-#: menus/menu-welcome.php:538
+#: menus/menu-welcome.php:541
 msgid "Fix: New label now appears on listings not just with an inspection time saved."
 msgstr ""
 
-#: menus/menu-welcome.php:539
+#: menus/menu-welcome.php:542
 msgid "Tweak: Optimised loading of admin scripts and styles to pages where required."
 msgstr ""
 
-#: menus/menu-welcome.php:540
+#: menus/menu-welcome.php:543
 msgid ""
 "Tweak: Added version to CSS and JS so new versions are automatically used when plugin "
 "is updated."
 msgstr ""
 
-#: menus/menu-welcome.php:541
+#: menus/menu-welcome.php:544
 msgid "Tweak: Tidy up of admin CSS."
 msgstr ""
 
-#: menus/menu-welcome.php:542
+#: menus/menu-welcome.php:545
 msgid "Tweak: Video in author box now responsive."
 msgstr ""
 
-#: menus/menu-welcome.php:543
+#: menus/menu-welcome.php:546
 msgid ""
 "Tweak: Increased characters possible in address block fields from 40 to 80 characters "
 "and heading block to 200."
 msgstr ""
 
-#: menus/menu-welcome.php:544
+#: menus/menu-welcome.php:547
 msgid "Tweak: Coordinates now correctly being used to generate map."
 msgstr ""
 
-#: menus/menu-welcome.php:545
+#: menus/menu-welcome.php:548
 msgid "Tweak: Inspection times improved style in admin."
 msgstr ""
 
-#: menus/menu-welcome.php:546
+#: menus/menu-welcome.php:549
 msgid "Tweak: Commercial rental rate now accepts decimal numbers."
 msgstr ""
 
-#: menus/menu-welcome.php:547
+#: menus/menu-welcome.php:550
 msgid "Tweak: Improved google map output."
 msgstr ""
 
-#: menus/menu-welcome.php:548
+#: menus/menu-welcome.php:551
 msgid "Tweak: Improved default settings on upgrade, install and multisite."
 msgstr ""
 
-#: menus/menu-welcome.php:549
+#: menus/menu-welcome.php:552
 msgid "Tweak: Scripts improve site speed."
 msgstr ""
 
-#: menus/menu-welcome.php:550
+#: menus/menu-welcome.php:553
 msgid "Tweak: Dashboard widget improved query."
 msgstr ""
 
-#: menus/menu-welcome.php:551
+#: menus/menu-welcome.php:554
 msgid "Tweak: Front end CSS tweaks for better responsiveness."
 msgstr ""
 
-#: menus/menu-welcome.php:554
+#: menus/menu-welcome.php:557
 msgid "Version 2.0.3"
 msgstr ""
 
-#: menus/menu-welcome.php:556
+#: menus/menu-welcome.php:559
 msgid "Fix: Manually entered inspection capitalization fixed pM to PM."
 msgstr ""
 
-#: menus/menu-welcome.php:557
+#: menus/menu-welcome.php:560
 msgid "New: French translation (Thanks to Thomas Grimaud)"
 msgstr ""
 
-#: menus/menu-welcome.php:558
+#: menus/menu-welcome.php:561
 msgid "New: Finnish translation (Thanks to Turo)"
 msgstr ""
 
-#: menus/menu-welcome.php:561
+#: menus/menu-welcome.php:564
 msgid "Version 2.0.2"
 msgstr ""
 
-#: menus/menu-welcome.php:563
+#: menus/menu-welcome.php:566
 msgid ""
 "Fix: Added fall-back diff() function which is not present in PHP 5.2 or earlier used "
 "with the New label."
 msgstr ""
 
-#: menus/menu-welcome.php:564
+#: menus/menu-welcome.php:567
 msgid ""
 "Fix: Some Labels in settings were not saving correctly particularly the search widget "
 "labels."
 msgstr ""
 
-#: menus/menu-welcome.php:565
+#: menus/menu-welcome.php:568
 msgid "Fix: Restored missing author profile contact form tab on author box."
 msgstr ""
 
-#: menus/menu-welcome.php:566
+#: menus/menu-welcome.php:569
 msgid "Tweak: Added CSS version to admin CSS and front end CSS."
 msgstr ""
 
-#: menus/menu-welcome.php:569
+#: menus/menu-welcome.php:572
 msgid "Version 2.0.1"
 msgstr ""
 
-#: menus/menu-welcome.php:571
+#: menus/menu-welcome.php:574
 msgid ""
 "Fix: Attempted Twenty 15 CSS Fix but causes issues with other themes. Manual fix: "
 "Copy CSS from style-front.css to correct, margins and grid/sorter."
 msgstr ""
 
-#: menus/menu-welcome.php:572
+#: menus/menu-welcome.php:575
 msgid ""
 "Fix: Restored Display of Inspection Label for properties with scheduled inspection "
 "times."
 msgstr ""
 
-#: menus/menu-welcome.php:573
+#: menus/menu-welcome.php:576
 msgid "Fix: Search Widget security fix and performance improvements."
 msgstr ""
 
-#: menus/menu-welcome.php:576
+#: menus/menu-welcome.php:579
 msgid "Version 2.0"
 msgstr ""
 
-#: menus/menu-welcome.php:578
+#: menus/menu-welcome.php:581
 msgid "New: Extension validator."
 msgstr ""
 
-#: menus/menu-welcome.php:579
+#: menus/menu-welcome.php:582
 msgid "New: Depreciated listing-meta.php into compatibility folder."
 msgstr ""
 
-#: menus/menu-welcome.php:580
+#: menus/menu-welcome.php:583
 msgid "New: Depreciated author-meta.php into compatibility folder."
 msgstr ""
 
-#: menus/menu-welcome.php:581
+#: menus/menu-welcome.php:584
 msgid "New: Global variables: $property, $epl_author and $epl_settings."
 msgstr ""
 
-#: menus/menu-welcome.php:582
+#: menus/menu-welcome.php:585
 msgid "New: Added filters for fields and groups in /lib/meta-boxes.php"
 msgstr ""
 
-#: menus/menu-welcome.php:583
+#: menus/menu-welcome.php:586
 msgid ""
 "New: Property custom meta re-written into class. This was the big change to 2.0 where "
 "we completely re-wrote the output of the meta values which are now accessible using "
 "global $property variable and easy template actions."
 msgstr ""
 
-#: menus/menu-welcome.php:584
+#: menus/menu-welcome.php:587
 msgid ""
 "New: Property meta can now can be output using new actions for easy and quick custom "
 "template creation."
 msgstr ""
 
-#: menus/menu-welcome.php:585
+#: menus/menu-welcome.php:588
 msgid "New: Reconstructed templates for single, archive & author pages"
 msgstr ""
 
-#: menus/menu-welcome.php:586
+#: menus/menu-welcome.php:589
 msgid "Tweak: Removed unused price script"
 msgstr ""
 
-#: menus/menu-welcome.php:587
+#: menus/menu-welcome.php:590
 msgid "Fix: Fixed warning related to static instance in strict standard modes"
 msgstr ""
 
-#: menus/menu-welcome.php:588
+#: menus/menu-welcome.php:591
 msgid "New: API for extensions now support WordPress editor with validation."
 msgstr ""
 
-#: menus/menu-welcome.php:589
+#: menus/menu-welcome.php:592
 msgid ""
 "New: jQuery date time picker formatting added to improve support for auction and sold "
 "listing, support for 30+ languages support."
 msgstr ""
 
-#: menus/menu-welcome.php:590
+#: menus/menu-welcome.php:593
 msgid ""
 "New: Inspection time auto-formats REAXML date eg [13-Dec-2014 11:00am to 11:45am] and "
 "will no longer show past inspection times."
 msgstr ""
 
-#: menus/menu-welcome.php:591
+#: menus/menu-welcome.php:594
 msgid "New: Inspection time support multiple dates written one per line."
 msgstr ""
 
-#: menus/menu-welcome.php:592
+#: menus/menu-welcome.php:595
 msgid "Tweak: CSS improved with better commenting and size reduction."
 msgstr ""
 
-#: menus/menu-welcome.php:593
+#: menus/menu-welcome.php:596
 msgid ""
 "New: Dashboard widget now lists all listing status so at a glance you can see your "
 "property stock."
 msgstr ""
 
-#: menus/menu-welcome.php:594
+#: menus/menu-welcome.php:597
 msgid ""
 "New: Display: To enable grid, list and sorter your custom archive-listing.php "
 "template requires the new action hook epl_template_before_property_loop before the "
 "WordPress loop."
 msgstr ""
 
-#: menus/menu-welcome.php:595
+#: menus/menu-welcome.php:598
 msgid ""
 "New: Display: Utility hook action hook added epl_template_after_property_loop for "
 "future updates."
 msgstr ""
 
-#: menus/menu-welcome.php:596
+#: menus/menu-welcome.php:599
 msgid "New: Display: List and grid view with optional masonry effect."
 msgstr ""
 
-#: menus/menu-welcome.php:597
+#: menus/menu-welcome.php:600
 msgid "New: Display: Sorter added for price high/low and date newest/oldest."
 msgstr ""
 
-#: menus/menu-welcome.php:598
+#: menus/menu-welcome.php:601
 msgid "New: Auction Date formats nicely. EG [Auction Saturday 28th December at 2:00pm]."
 msgstr ""
 
-#: menus/menu-welcome.php:599
+#: menus/menu-welcome.php:602
 msgid ""
 "New: Tabbed extensions page support in admin for advanced extensions like Listing "
 "Alerts."
 msgstr ""
 
-#: menus/menu-welcome.php:600
+#: menus/menu-welcome.php:603
 msgid "New: Multiple author support in Author Box."
 msgstr ""
 
-#: menus/menu-welcome.php:601
+#: menus/menu-welcome.php:604
 msgid ""
 "New: Search Widget - Supports multiple listing types, hold Ctrl to enable tabbed "
 "front end display."
 msgstr ""
 
-#: menus/menu-welcome.php:602
+#: menus/menu-welcome.php:605
 msgid ""
 "New: Search Widget - Labels are configurable from the Display settings allowing you "
 "to set for example: Property to Buy and Rental to Rent and use a single widget to "
 "search multiple types."
 msgstr ""
 
-#: menus/menu-welcome.php:603
+#: menus/menu-welcome.php:606
 msgid ""
 "New: Search Widget and shortcode supports search by property ID, post Title, Land "
 "Area and Building Area."
 msgstr ""
 
-#: menus/menu-welcome.php:604
+#: menus/menu-welcome.php:607
 msgid ""
 "New: Search Widget - removed extra fields from land, added labels for each property "
 "type to be shown as tab heading in search widget"
 msgstr ""
 
-#: menus/menu-welcome.php:605
+#: menus/menu-welcome.php:608
 msgid ""
 "Fix: Search Widget - Optimized total queries due to search widget from 1500 + to ~40"
 msgstr ""
 
-#: menus/menu-welcome.php:606
+#: menus/menu-welcome.php:609
 msgid "New: Author variables accessible using new CLASS."
 msgstr ""
 
-#: menus/menu-welcome.php:607
+#: menus/menu-welcome.php:610
 msgid "New: Search short code supports array of property types."
 msgstr ""
 
-#: menus/menu-welcome.php:608
+#: menus/menu-welcome.php:611
 msgid ""
 "New: REAXML date format function to format date correctly when using WP All Import "
 "Pro. Usage [epl_feedsync_format_date({./@modTime})]."
 msgstr ""
 
-#: menus/menu-welcome.php:609
+#: menus/menu-welcome.php:612
 msgid ""
 "New: REAXML Unit and lot formatting function for usage in the title when using WP All "
 "Import Pro. Usage [epl_feedsync_filter_sub_number({address[1]/subNumber[1]})]."
 msgstr ""
 
-#: menus/menu-welcome.php:610
+#: menus/menu-welcome.php:613
 msgid ""
 "New: Global $epl_settings settings variable adds new default values on plugin update."
 msgstr ""
 
-#: menus/menu-welcome.php:611
+#: menus/menu-welcome.php:614
 msgid "New: Display: Added customisable label for rental Bond/Deposit."
 msgstr ""
 
-#: menus/menu-welcome.php:612
+#: menus/menu-welcome.php:615
 msgid ""
 "New: Template functions completely re-written and can now be output using actions."
 msgstr ""
 
-#: menus/menu-welcome.php:613
+#: menus/menu-welcome.php:616
 msgid ""
 "New: Added NEW sticker with customisable label and ability to set how long a listing "
 "displays the new label."
 msgstr ""
 
-#: menus/menu-welcome.php:614
+#: menus/menu-welcome.php:617
 msgid "Tweak: Compatibility fixes"
 msgstr ""
 
-#: menus/menu-welcome.php:615
+#: menus/menu-welcome.php:618
 msgid "New: Bar Graph API added."
 msgstr ""
 
-#: menus/menu-welcome.php:616
+#: menus/menu-welcome.php:619
 msgid ""
 "New: Graph in admin allows you to set the max bar graph value. Default are (2,000,000 "
 "sale) and (2,000 rental)."
 msgstr ""
 
-#: menus/menu-welcome.php:617
+#: menus/menu-welcome.php:620
 msgid "New: Graph visually displays price and status."
 msgstr ""
 
-#: menus/menu-welcome.php:618
+#: menus/menu-welcome.php:621
 msgid ""
 "New: Price graph now appears in admin pages quickly highlighting price and status "
 "visually."
 msgstr ""
 
-#: menus/menu-welcome.php:619
+#: menus/menu-welcome.php:622
 msgid "New: Meta Fields: Support for unit number, lot number (land)."
 msgstr ""
 
-#: menus/menu-welcome.php:620
+#: menus/menu-welcome.php:623
 msgid "New: South African ZAR currency support."
 msgstr ""
 
-#: menus/menu-welcome.php:621
+#: menus/menu-welcome.php:624
 msgid "Fix: Corrected Commercial Features ID Spelling"
 msgstr ""
 
-#: menus/menu-welcome.php:622
+#: menus/menu-welcome.php:625
 msgid ""
 "Tweak: YouTube video src to id function is replaced with better method which handles "
 "multiple YouTube video formats including shortened & embedded format"
 msgstr ""
 
-#: menus/menu-welcome.php:623
+#: menus/menu-welcome.php:626
 msgid "New: Adding Sold Date processing"
 msgstr ""
 
-#: menus/menu-welcome.php:624
+#: menus/menu-welcome.php:627
 msgid "Tweak: Updated shortcode templates"
 msgstr ""
 
-#: menus/menu-welcome.php:625
+#: menus/menu-welcome.php:628
 msgid "Tweak: Global $epl_author."
 msgstr ""
 
-#: menus/menu-welcome.php:626
+#: menus/menu-welcome.php:629
 msgid "Tweak: Fixed content/ into EPL_PATH_TEMPLATES_CONTENT"
 msgstr ""
 
-#: menus/menu-welcome.php:627
+#: menus/menu-welcome.php:630
 msgid "New: Support for older extensions added"
 msgstr ""
 
-#: menus/menu-welcome.php:628
+#: menus/menu-welcome.php:631
 msgid "New: Extension offers in menus general tab"
 msgstr ""
 
-#: menus/menu-welcome.php:629
+#: menus/menu-welcome.php:632
 msgid ""
 "Tweak: Renamed user profile options section to [Easy Property Listings: Author Box "
 "Profile]."
 msgstr ""
 
-#: menus/menu-welcome.php:630
+#: menus/menu-welcome.php:633
 msgid "Tweak: Added better Bond/Deposit for rentals labels."
 msgstr ""
 
-#: menus/menu-welcome.php:631
+#: menus/menu-welcome.php:634
 msgid ""
 "Fix: Deprecated author-meta.php in compatibility folder, class-author-meta.php has "
 "been created which will be used in place of author-meta.php & its variables in all "
 "author templates"
 msgstr ""
 
-#: menus/menu-welcome.php:632
+#: menus/menu-welcome.php:635
 msgid ""
 "New: Added template functions for author meta class, modified templates lib/templates/"
 "content/content-author-box-simple-card.php lib/templates/content/content-author-box-"
@@ -3254,545 +3266,545 @@ msgid ""
 "functions based on author meta class instead of variables from author-meta.php"
 msgstr ""
 
-#: menus/menu-welcome.php:633
+#: menus/menu-welcome.php:636
 msgid ""
 "New: author-meta.php depreciated and moved to compatibility directory. Variables "
 "globally available using $epl_author variable."
 msgstr ""
 
-#: menus/menu-welcome.php:634
+#: menus/menu-welcome.php:637
 msgid ""
 "Tweak: listing-meta.php depreciated and moved to compatibility directory. Variables "
 "globally available with $property variable."
 msgstr ""
 
-#: menus/menu-welcome.php:635
+#: menus/menu-welcome.php:638
 msgid ""
 "Tweak: Added Listing not Found to default templates when search performed with no "
 "results."
 msgstr ""
 
-#: menus/menu-welcome.php:636
+#: menus/menu-welcome.php:639
 msgid "Tweak: Improved Google maps address output for addresses containing # and /."
 msgstr ""
 
-#: menus/menu-welcome.php:637
+#: menus/menu-welcome.php:640
 msgid ""
 "Fix: Listing Pages now have better responsive support for small screen devices like "
 "iPhone."
 msgstr ""
 
-#: menus/menu-welcome.php:638
+#: menus/menu-welcome.php:641
 msgid ""
 "Fix: Default templates for Genesis and TwentyTwelve now show Listing Not Found when a "
 "search result returns empty."
 msgstr ""
 
-#: menus/menu-welcome.php:639
+#: menus/menu-welcome.php:642
 msgid "Fix: Purged translations in epl.pot file."
 msgstr ""
 
-#: menus/menu-welcome.php:640
+#: menus/menu-welcome.php:643
 msgid "Fix: Search Widget and short code drastically reduces database queries."
 msgstr ""
 
-#: menus/menu-welcome.php:641
+#: menus/menu-welcome.php:644
 msgid ""
 "New: Templates are now able to be saved in active theme folder /easypropertylistings "
 "and edited. Plugin will use these first and fall back to plugin if not located in "
 "theme folder."
 msgstr ""
 
-#: menus/menu-welcome.php:642
+#: menus/menu-welcome.php:645
 msgid "Fix: Extensions Notification and checker updated"
 msgstr ""
 
-#: menus/menu-welcome.php:643
+#: menus/menu-welcome.php:646
 msgid "New: updated author templates to use new author meta class"
 msgstr ""
 
-#: menus/menu-welcome.php:644
+#: menus/menu-welcome.php:647
 msgid ""
 "Fix: Added prefix to CSS tab-content class. Now epl-tab-content for compatibility."
 msgstr ""
 
-#: menus/menu-welcome.php:645
+#: menus/menu-welcome.php:648
 msgid "New: Update user.php"
 msgstr ""
 
-#: menus/menu-welcome.php:646
+#: menus/menu-welcome.php:649
 msgid "Tweak: Improved internal documentation and updated screens."
 msgstr ""
 
-#: menus/menu-welcome.php:647
+#: menus/menu-welcome.php:650
 msgid "Tweak: Improved descriptions on author pages."
 msgstr ""
 
-#: menus/menu-welcome.php:648
+#: menus/menu-welcome.php:651
 msgid "Tweak: Better permalink flushing on activation, deactivation and install."
 msgstr ""
 
-#: menus/menu-welcome.php:649
+#: menus/menu-welcome.php:652
 msgid "Tweak: Extensive changes to admin descriptions and labels."
 msgstr ""
 
-#: menus/menu-welcome.php:650
+#: menus/menu-welcome.php:653
 msgid "Tweak: Optimising the php loading of files and scripts."
 msgstr ""
 
-#: menus/menu-welcome.php:651
+#: menus/menu-welcome.php:654
 msgid "New: Define EPL_RUNNING added for extensions to check if plugin is active."
 msgstr ""
 
-#: menus/menu-welcome.php:652
+#: menus/menu-welcome.php:655
 msgid "New: New options added to setting array when plugin is updated."
 msgstr ""
 
-#: menus/menu-welcome.php:653
+#: menus/menu-welcome.php:656
 msgid ""
 "New: Old functions and files moved to plug-in /compatibility folder to ensure old "
 "code still works."
 msgstr ""
 
-#: menus/menu-welcome.php:654
+#: menus/menu-welcome.php:657
 msgid "New: Meta Location Label."
 msgstr ""
 
-#: menus/menu-welcome.php:655
+#: menus/menu-welcome.php:658
 msgid "New: Service banners on settings page."
 msgstr ""
 
-#: menus/menu-welcome.php:656
+#: menus/menu-welcome.php:659
 msgid "New: Saving version number so when updating new settings are added."
 msgstr ""
 
-#: menus/menu-welcome.php:657
+#: menus/menu-welcome.php:660
 msgid ""
 "New: iCal functionality for REAXML formatted inspection dates. Further improvements "
 "coming for manual date entry. "
 msgstr ""
 
-#: menus/menu-welcome.php:658
+#: menus/menu-welcome.php:661
 msgid "New: Extensions options pages now with tabs for easier usage."
 msgstr ""
 
-#: menus/menu-welcome.php:659
+#: menus/menu-welcome.php:662
 msgid "New: Added ID classes to admin pages and meta fields."
 msgstr ""
 
-#: menus/menu-welcome.php:660
+#: menus/menu-welcome.php:663
 msgid "New: Filters to adjust land and building sizes from number to select fields."
 msgstr ""
 
-#: menus/menu-welcome.php:661
+#: menus/menu-welcome.php:664
 msgid ""
 "Tweak: Moved old extensions options page to compatibility folder so older extensions "
 "still work as expected."
 msgstr ""
 
-#: menus/menu-welcome.php:662
+#: menus/menu-welcome.php:665
 msgid ""
 "New: Search Widget - Added filter for land min & max fields in listing search widget"
 msgstr ""
 
-#: menus/menu-welcome.php:663
+#: menus/menu-welcome.php:666
 msgid ""
 "New: Search Widget - Added filter for building min & max fields in listing search "
 "widget"
 msgstr ""
 
-#: menus/menu-welcome.php:664
+#: menus/menu-welcome.php:667
 msgid "Fix: For session start effecting certain themes"
 msgstr ""
 
-#: menus/menu-welcome.php:665
+#: menus/menu-welcome.php:668
 msgid "New: Land sizes now allow up to 5 decimal places"
 msgstr ""
 
-#: menus/menu-welcome.php:666
+#: menus/menu-welcome.php:669
 msgid "New: Search Widget - Custom submit label"
 msgstr ""
 
-#: menus/menu-welcome.php:667
+#: menus/menu-welcome.php:670
 msgid "New: Search Widget - Can search by title in property ID / Address field"
 msgstr ""
 
-#: menus/menu-welcome.php:668
+#: menus/menu-welcome.php:671
 msgid "New: Added Russian Translation"
 msgstr ""
 
-#: menus/menu-welcome.php:671
+#: menus/menu-welcome.php:674
 msgid "Version 1.2.1"
 msgstr ""
 
-#: menus/menu-welcome.php:673
+#: menus/menu-welcome.php:676
 msgid "Fix: Search Widget not working on page 2 of archive page in some instances"
 msgstr ""
 
-#: menus/menu-welcome.php:674
+#: menus/menu-welcome.php:677
 msgid ""
 "Fix: Property feature list Toilet and New Construction now display in list when ticked"
 msgstr ""
 
-#: menus/menu-welcome.php:675
+#: menus/menu-welcome.php:678
 msgid "Fix: EPL - Listing widget was not displaying featured listings"
 msgstr ""
 
-#: menus/menu-welcome.php:676
+#: menus/menu-welcome.php:679
 msgid ""
 "Fix: Allowed to filter by commercial_listing_type in [listing_category] shortcode"
 msgstr ""
 
-#: menus/menu-welcome.php:677
+#: menus/menu-welcome.php:680
 msgid "Fix: Updated templates to display Search Results when performing search"
 msgstr ""
 
-#: menus/menu-welcome.php:678
+#: menus/menu-welcome.php:681
 msgid "Fix: No longer show Bond when viewing rental list in admin"
 msgstr ""
 
-#: menus/menu-welcome.php:679
+#: menus/menu-welcome.php:682
 msgid "Fix: Open for inspection sticker now appears on rental properties"
 msgstr ""
 
-#: menus/menu-welcome.php:680
+#: menus/menu-welcome.php:683
 msgid "New: Added initial Dutch translation."
 msgstr ""
 
-#: menus/menu-welcome.php:683
+#: menus/menu-welcome.php:686
 msgid "Version 1.2"
 msgstr ""
 
-#: menus/menu-welcome.php:685
+#: menus/menu-welcome.php:688
 msgid "New: Plug in Activation process flushes permalinks"
 msgstr ""
 
-#: menus/menu-welcome.php:686
+#: menus/menu-welcome.php:689
 msgid "New: Plug in deactivation flushes permalinks"
 msgstr ""
 
-#: menus/menu-welcome.php:687
+#: menus/menu-welcome.php:690
 msgid "New: Shortcode [listing_search]"
 msgstr ""
 
-#: menus/menu-welcome.php:688
+#: menus/menu-welcome.php:691
 msgid "New: Shortcode [listing_feature]"
 msgstr ""
 
-#: menus/menu-welcome.php:689
+#: menus/menu-welcome.php:692
 msgid ""
 "New: Shortcode [listing_open] replaces [home_open] shortcode. Retained [home_open] "
 "for backward compatibility, however adjust your site. "
 msgstr ""
 
-#: menus/menu-welcome.php:690
+#: menus/menu-welcome.php:693
 msgid ""
 "New: Listing shortcodes allow for default template display if registered by adding "
 "template=\"slim\" to the shortcode."
 msgstr ""
 
-#: menus/menu-welcome.php:691
+#: menus/menu-welcome.php:694
 msgid "New: Translation support now correctly loads text domain epl"
 msgstr ""
 
-#: menus/menu-welcome.php:692
+#: menus/menu-welcome.php:695
 msgid "New: Added translation tags to all test elements for better translation support"
 msgstr ""
 
-#: menus/menu-welcome.php:693
+#: menus/menu-welcome.php:696
 msgid "New: Updated source epl.pot translation file for translations"
 msgstr ""
 
-#: menus/menu-welcome.php:694
+#: menus/menu-welcome.php:697
 msgid "New: Added very rough Italian translation"
 msgstr ""
 
-#: menus/menu-welcome.php:695
+#: menus/menu-welcome.php:698
 msgid ""
 "New: Wrapped Featured image in action to allow for easy removal and/or replacement"
 msgstr ""
 
-#: menus/menu-welcome.php:696
+#: menus/menu-welcome.php:699
 msgid "Fix: Undefined errors when debug is active"
 msgstr ""
 
-#: menus/menu-welcome.php:697
+#: menus/menu-welcome.php:700
 msgid "New: Added new CSS classes to widgets for consistent usage"
 msgstr ""
 
-#: menus/menu-welcome.php:698
+#: menus/menu-welcome.php:701
 msgid "Tweak: Admin CSS tweaks to define sections in admin"
 msgstr ""
 
-#: menus/menu-welcome.php:699
+#: menus/menu-welcome.php:702
 msgid "Fix: CSS for TwentyThirteen style CSS using .sidebar container"
 msgstr ""
 
-#: menus/menu-welcome.php:700
+#: menus/menu-welcome.php:703
 msgid "Fix: CSS for responsive shortcode"
 msgstr ""
 
-#: menus/menu-welcome.php:701
+#: menus/menu-welcome.php:704
 msgid ""
 "New: Added options to hide/ show various options to EPL - Listing widget: Property "
 "Headline, Excerpt, Suburb/Location Label, Street Address, Price, Read More Button"
 msgstr ""
 
-#: menus/menu-welcome.php:702
+#: menus/menu-welcome.php:705
 msgid "New: Added customisable \"Read More\" label to EPL - Listing widget"
 msgstr ""
 
-#: menus/menu-welcome.php:703
+#: menus/menu-welcome.php:706
 msgid "New: Added excerpt to EPL - Listing widget"
 msgstr ""
 
-#: menus/menu-welcome.php:704
+#: menus/menu-welcome.php:707
 msgid "New: Added options to remove search options from EPL - Listing Search widget"
 msgstr ""
 
-#: menus/menu-welcome.php:705
+#: menus/menu-welcome.php:708
 msgid "New: Added consistent CSS classes to shortcodes for responsive shortcode"
 msgstr ""
 
-#: menus/menu-welcome.php:706
+#: menus/menu-welcome.php:709
 msgid ""
 "New: Date processing function for use with WP All Import when importing REAXML files. "
 "Some imports set the current date instead of the date from the REAXML file. Usage in "
 "WP All Import Post Date is: [epl_feedsync_format_date({./@modTime})]"
 msgstr ""
 
-#: menus/menu-welcome.php:707
+#: menus/menu-welcome.php:710
 msgid ""
 "Tweak: Added additional CSS classes to admin menu pages to extensions can be better "
 "distinguished when installed and activated"
 msgstr ""
 
-#: menus/menu-welcome.php:708
+#: menus/menu-welcome.php:711
 msgid "Fix: Registering custom template actions now works correctly"
 msgstr ""
 
-#: menus/menu-welcome.php:709
+#: menus/menu-welcome.php:712
 msgid "New: Added additional CSS classes to template files"
 msgstr ""
 
-#: menus/menu-welcome.php:710
+#: menus/menu-welcome.php:713
 msgid ""
 "Fix: Changed property not found wording when using search widget and listing not "
 "found. "
 msgstr ""
 
-#: menus/menu-welcome.php:711
+#: menus/menu-welcome.php:714
 msgid "Tweak: Added defaults to widgets to prevent errors when debug is on"
 msgstr ""
 
-#: menus/menu-welcome.php:712
+#: menus/menu-welcome.php:715
 msgid "New: Added WordPress editor support in admin for use with extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:713
+#: menus/menu-welcome.php:716
 msgid "New: Added textarea support in admin for use with extensions."
 msgstr ""
 
-#: menus/menu-welcome.php:714
+#: menus/menu-welcome.php:717
 msgid ""
 "New: Filters added for all select options on add listing pages which allows for full "
 "customisation through simple function"
 msgstr ""
 
-#: menus/menu-welcome.php:715
+#: menus/menu-welcome.php:718
 msgid "New: Added rent period, Day, Daily, Month, Monthly to rental listing types"
 msgstr ""
 
-#: menus/menu-welcome.php:716
+#: menus/menu-welcome.php:719
 msgid "New: Added property_office_id meta field"
 msgstr ""
 
-#: menus/menu-welcome.php:717
+#: menus/menu-welcome.php:720
 msgid "New: Added property_address_country meta field"
 msgstr ""
 
-#: menus/menu-welcome.php:718
+#: menus/menu-welcome.php:721
 msgid "Tweak: Allowed for decimal in bathrooms to allow for 1/2 baths eg 1.5"
 msgstr ""
 
-#: menus/menu-welcome.php:719
+#: menus/menu-welcome.php:722
 msgid ""
 "New: Added mini map to listing edit screen. Will display mini map in address block "
 "when pressing green coordinates button."
 msgstr ""
 
-#: menus/menu-welcome.php:720
+#: menus/menu-welcome.php:723
 msgid ""
 "Fix: Updated admin columns for commercial_land listing type to match other listing "
 "type"
 msgstr ""
 
-#: menus/menu-welcome.php:721
+#: menus/menu-welcome.php:724
 msgid "Fix: Swapped bedrooms/bathroom label on hover"
 msgstr ""
 
-#: menus/menu-welcome.php:722
+#: menus/menu-welcome.php:725
 msgid ""
 "New: Added filter epl_listing_meta_boxes which allows additional meta boxes to be "
 "added through filter"
 msgstr ""
 
-#: menus/menu-welcome.php:725
+#: menus/menu-welcome.php:728
 msgid "Version 1.1.1"
 msgstr ""
 
-#: menus/menu-welcome.php:727
+#: menus/menu-welcome.php:730
 msgid ""
 "New: Internationalisation support to enable customizing of post types: slug, archive, "
 "rewrite, labels, listing categories for meta_types."
 msgstr ""
 
-#: menus/menu-welcome.php:728
+#: menus/menu-welcome.php:731
 msgid ""
 "New: Created filters for listing meta select fields: property_category, "
 "property_rural_category, property_commercial_category, property_land_category."
 msgstr ""
 
-#: menus/menu-welcome.php:729
+#: menus/menu-welcome.php:732
 msgid ""
 "New: Created filters for each of the seven custom post types: labels, supports, slug, "
 "archive, rewrite, seven custom post types."
 msgstr ""
 
-#: menus/menu-welcome.php:730
+#: menus/menu-welcome.php:733
 msgid ""
 "New: Shortcode [listing_category] This shortcode allows for you to output a list of "
 "listings by type and filter them by any available meta key and value."
 msgstr ""
 
-#: menus/menu-welcome.php:731
+#: menus/menu-welcome.php:734
 msgid "Tweak: Updated search widget for filtered property_categories."
 msgstr ""
 
-#: menus/menu-welcome.php:732
+#: menus/menu-welcome.php:735
 msgid "Fix: Listing categories were showing key, now showing value."
 msgstr ""
 
-#: menus/menu-welcome.php:733
+#: menus/menu-welcome.php:736
 msgid ""
 "Fix: Settings were not showing up after saving, second refresh required setting "
 "variable to reload."
 msgstr ""
 
-#: menus/menu-welcome.php:736
+#: menus/menu-welcome.php:739
 msgid "Version 1.1"
 msgstr ""
 
-#: menus/menu-welcome.php:738
+#: menus/menu-welcome.php:741
 msgid "First official release!"
 msgstr ""
 
-#: menus/menu-welcome.php:744
+#: menus/menu-welcome.php:747
 msgid "Go to Easy Property Listings Settings"
 msgstr ""
 
-#: menus/menu-welcome.php:768
+#: menus/menu-welcome.php:771
 msgid "Real Estate Tools for WordPress"
 msgstr ""
 
-#: menus/menu-welcome.php:776
+#: menus/menu-welcome.php:779
 msgid "Quick Start Guide"
 msgstr ""
 
-#: menus/menu-welcome.php:778
+#: menus/menu-welcome.php:781
 msgid ""
 "Use the tips below to get started using Easy Property Listings. You will be up and "
 "running in no time!"
 msgstr ""
 
-#: menus/menu-welcome.php:782
+#: menus/menu-welcome.php:785
 msgid "Activate the listing types you need & configure the plugin general settings"
 msgstr ""
 
-#: menus/menu-welcome.php:783 menus/menu-welcome.php:825
+#: menus/menu-welcome.php:786 menus/menu-welcome.php:828
 msgid "Create a blank page for each activated listing type"
 msgstr ""
 
-#: menus/menu-welcome.php:784
+#: menus/menu-welcome.php:787
 msgid "Publish your first listing for testing your theme setup"
 msgstr ""
 
-#: menus/menu-welcome.php:786
+#: menus/menu-welcome.php:789
 msgid "Setup your theme to work with the plugin"
 msgstr ""
 
-#: menus/menu-welcome.php:795
+#: menus/menu-welcome.php:798
 msgid "Activate the listing types you need"
 msgstr ""
 
-#: menus/menu-welcome.php:801
+#: menus/menu-welcome.php:804
 msgid ""
 "Visit the general settings page and enable the listing types you need. Once you have "
 "pressed save visit the Permalinks page to re-fresh your sites permalinks."
 msgstr ""
 
-#: menus/menu-welcome.php:803
+#: menus/menu-welcome.php:806
 msgid ""
 "Instead of classifying everything as a property, Easy Property Listings allows you to "
 "separate the different listing types which is better for SEO and RSS feeds."
 msgstr ""
 
-#: menus/menu-welcome.php:805
+#: menus/menu-welcome.php:808
 msgid "Supported Listing Types"
 msgstr ""
 
-#: menus/menu-welcome.php:830
+#: menus/menu-welcome.php:833
 msgid ""
 "Doing this allows you to add \"Property\", \"Land\" and \"Rental\" pages to your "
 "WordPress menu. Add a new page for each listing type you activated."
 msgstr ""
 
-#: menus/menu-welcome.php:832
+#: menus/menu-welcome.php:835
 msgid ""
 "For example, lets say you have activated: Property, Rental and Land. Create three "
 "pages, one called \"Property\", another \"Land\" and the third \"Rental\" these will "
 "be the custom post type slugs/permalinks eg: property, rental and land."
 msgstr ""
 
-#: menus/menu-welcome.php:834
+#: menus/menu-welcome.php:837
 msgid ""
 "Publish a test \"Property Listing\" and visit your new property page and you will see "
 "the new property and others you have created."
 msgstr ""
 
-#: menus/menu-welcome.php:836
+#: menus/menu-welcome.php:839
 msgid ""
 "Now you can rename them to whatever you like eg: \"For Sale\", \"For Rent\" etc, but "
 "leave the slug/permalink as it was,"
 msgstr ""
 
-#: menus/menu-welcome.php:836
+#: menus/menu-welcome.php:839
 msgid "this is very important."
 msgstr ""
 
-#: menus/menu-welcome.php:849
+#: menus/menu-welcome.php:852
 msgid "Publish Your First Listing"
 msgstr ""
 
-#: menus/menu-welcome.php:854
+#: menus/menu-welcome.php:857
 msgid "Title & Author"
 msgstr ""
 
-#: menus/menu-welcome.php:861
+#: menus/menu-welcome.php:864
 msgid "Use the full listing address as the title."
 msgstr ""
 
-#: menus/menu-welcome.php:863
+#: menus/menu-welcome.php:866
 msgid ""
 "When a property is being sold the \"heading\" is frequently changed and can cause "
 "permalink issues. Not to mention the search engine benefits."
 msgstr ""
 
-#: menus/menu-welcome.php:865
+#: menus/menu-welcome.php:868
 msgid "Author or Primary Real Estate Agent"
 msgstr ""
 
-#: menus/menu-welcome.php:866
+#: menus/menu-welcome.php:869
 msgid ""
 "Select the author to show the name of the agent who has listed the property with "
 "their contact details. For best results each real estate agent should have their own "
@@ -3800,257 +3812,257 @@ msgid ""
 "and in widgets."
 msgstr ""
 
-#: menus/menu-welcome.php:875
+#: menus/menu-welcome.php:878
 msgid "Gallery and Featured Image"
 msgstr ""
 
-#: menus/menu-welcome.php:880
+#: menus/menu-welcome.php:883
 msgid "Gallery"
 msgstr ""
 
-#: menus/menu-welcome.php:883
+#: menus/menu-welcome.php:886
 msgid "You can automatically output a gallery from the Display options page."
 msgstr ""
 
-#: menus/menu-welcome.php:885
+#: menus/menu-welcome.php:888
 msgid ""
 "If set to automatic, just upload your images to the listing and press x to close the "
 "media upload box once the images are attached to the listing. You can also easily "
 "adjust the number of gallery columns from the plugin Display options."
 msgstr ""
 
-#: menus/menu-welcome.php:887
+#: menus/menu-welcome.php:890
 msgid "Gallery Light Box"
 msgstr ""
 
-#: menus/menu-welcome.php:888
+#: menus/menu-welcome.php:891
 msgid ""
 "Using a light box plug-in like Easy FancyBox, your automatic gallery images will use "
 "the light box effect."
 msgstr ""
 
-#: menus/menu-welcome.php:912
+#: menus/menu-welcome.php:915
 msgid ""
 "Now supports multiple inspection times, add one per line. Past inspection dates will "
 "not display when using the new format."
 msgstr ""
 
-#: menus/menu-welcome.php:914
+#: menus/menu-welcome.php:917
 msgid ""
 "The output is now wrapped in an iCal format so clicking on the date will open the "
 "users calendar."
 msgstr ""
 
-#: menus/menu-welcome.php:927
+#: menus/menu-welcome.php:930
 msgid "Configure your theme"
 msgstr ""
 
-#: menus/menu-welcome.php:928
+#: menus/menu-welcome.php:931
 msgid ""
 "We have done our best to integrate Easy Property Listings with all WordPress themes."
 msgstr ""
 
-#: menus/menu-welcome.php:934
+#: menus/menu-welcome.php:937
 msgid ""
 "Once you add a listing and if your page is really wide or your sidebar is under the "
 "content enable Theme Compatibility mode from settings."
 msgstr ""
 
-#: menus/menu-welcome.php:936
+#: menus/menu-welcome.php:939
 msgid ""
 "Review your listing and if you are seeing double images, hop back over to Settings "
 "page and either disable the theme feature image or the one provided by Easy Property "
 "Listings."
 msgstr ""
 
-#: menus/menu-welcome.php:938
+#: menus/menu-welcome.php:941
 msgid "Shortcodes"
 msgstr ""
 
-#: menus/menu-welcome.php:940
+#: menus/menu-welcome.php:943
 msgid ""
 "The featured image settings have no impact on the Easy Property Listings shortcodes "
 "and widgets."
 msgstr ""
 
-#: menus/menu-welcome.php:945
+#: menus/menu-welcome.php:948
 msgid "Theme Compatibility not required for some themes"
 msgstr ""
 
-#: menus/menu-welcome.php:947
+#: menus/menu-welcome.php:950
 msgid "iThemes Builder Themes"
 msgstr ""
 
-#: menus/menu-welcome.php:948
+#: menus/menu-welcome.php:951
 msgid "Genesis Framework by StudioPress"
 msgstr ""
 
-#: menus/menu-welcome.php:949
+#: menus/menu-welcome.php:952
 msgid "Twenty 12, 13, 14 &#38; 15 by WordPress."
 msgstr ""
 
-#: menus/menu-welcome.php:950
+#: menus/menu-welcome.php:953
 msgid "Many others, add a listing and see how it looks."
 msgstr ""
 
-#: menus/menu-welcome.php:952
+#: menus/menu-welcome.php:955
 msgid "We have a selection of pre configured templates here for many popular themes"
 msgstr ""
 
-#: menus/menu-welcome.php:952
+#: menus/menu-welcome.php:955
 msgid "here"
 msgstr ""
 
-#: menus/menu-welcome.php:958
+#: menus/menu-welcome.php:961
 msgid "Advanced theme integration instructions"
 msgstr ""
 
-#: menus/menu-welcome.php:959
+#: menus/menu-welcome.php:962
 msgid "Before attempting the following steps add a"
 msgstr ""
 
-#: menus/menu-welcome.php:959
+#: menus/menu-welcome.php:962
 msgid "test listing"
 msgstr ""
 
-#: menus/menu-welcome.php:959
+#: menus/menu-welcome.php:962
 msgid "and preview it. Your theme may already work with Easy Property Listings."
 msgstr ""
 
-#: menus/menu-welcome.php:963
+#: menus/menu-welcome.php:966
 msgid "1. Take a backup of your theme and a copy of the files to edit."
 msgstr ""
 
-#: menus/menu-welcome.php:965
+#: menus/menu-welcome.php:968
 msgid ""
 "Open your favourite FTP program or access the file manager via your hosting panel."
 msgstr ""
 
-#: menus/menu-welcome.php:967
+#: menus/menu-welcome.php:970
 msgid "Take a backup of your theme before you start."
 msgstr ""
 
-#: menus/menu-welcome.php:969
+#: menus/menu-welcome.php:972
 msgid ""
 "Download the single.php file and archive.php from your theme folder and save it to "
 "your computer."
 msgstr ""
 
-#: menus/menu-welcome.php:970
+#: menus/menu-welcome.php:973
 msgid ""
 "If these files are not present in your child theme then copy them from your parent "
 "theme folder. If there is no archive.php file use the index.php file."
 msgstr ""
 
-#: menus/menu-welcome.php:973
+#: menus/menu-welcome.php:976
 msgid ""
 "On your computer rename single.php to single-listing.php and rename archive.php to "
 "archive-listing.php"
 msgstr ""
 
-#: menus/menu-welcome.php:975
+#: menus/menu-welcome.php:978
 msgid "If using index.php, rename that to archive-listing.php"
 msgstr ""
 
-#: menus/menu-welcome.php:977
+#: menus/menu-welcome.php:980
 msgid "Upload these new files back into your theme folder."
 msgstr ""
 
-#: menus/menu-welcome.php:981
+#: menus/menu-welcome.php:984
 msgid "2. Edit your single-listing.php file."
 msgstr ""
 
-#: menus/menu-welcome.php:983
+#: menus/menu-welcome.php:986
 msgid "Open your new single-listing.php file in your text editor like Notepad++."
 msgstr ""
 
-#: menus/menu-welcome.php:984 menus/menu-welcome.php:1001
+#: menus/menu-welcome.php:987 menus/menu-welcome.php:1004
 msgid "Look for"
 msgstr ""
 
-#: menus/menu-welcome.php:985
+#: menus/menu-welcome.php:988
 msgid "which appears after"
 msgstr ""
 
-#: menus/menu-welcome.php:986 menus/menu-welcome.php:1005
+#: menus/menu-welcome.php:989 menus/menu-welcome.php:1008
 msgid "Replace"
 msgstr ""
 
-#: menus/menu-welcome.php:989
+#: menus/menu-welcome.php:992
 msgid "with"
 msgstr ""
 
-#: menus/menu-welcome.php:992 menus/menu-welcome.php:1011
+#: menus/menu-welcome.php:995 menus/menu-welcome.php:1014
 msgid "Save the file and make sure you have sent it to the server."
 msgstr ""
 
-#: menus/menu-welcome.php:993
+#: menus/menu-welcome.php:996
 msgid "View the test listing you created and you should be done."
 msgstr ""
 
-#: menus/menu-welcome.php:998
+#: menus/menu-welcome.php:1001
 msgid "3. Edit your archive-listing.php file."
 msgstr ""
 
-#: menus/menu-welcome.php:1000
+#: menus/menu-welcome.php:1003
 msgid "Open archive-listing.php"
 msgstr ""
 
-#: menus/menu-welcome.php:1002
+#: menus/menu-welcome.php:1005
 msgid "which appears after the second"
 msgstr ""
 
-#: menus/menu-welcome.php:1003
+#: menus/menu-welcome.php:1006
 msgid "The first one is usually the page title."
 msgstr ""
 
-#: menus/menu-welcome.php:1012
+#: menus/menu-welcome.php:1015
 msgid ""
 "Check the main property page <code>http://YOUR_SITE_URL/property/</code> and you "
 "should be done."
 msgstr ""
 
-#: menus/menu-welcome.php:1017
+#: menus/menu-welcome.php:1020
 msgid "4. Optional for grid and sorter. Edit your archive-listing.php file again."
 msgstr ""
 
-#: menus/menu-welcome.php:1019 menus/menu-welcome.php:1026
+#: menus/menu-welcome.php:1022 menus/menu-welcome.php:1029
 msgid "Insert"
 msgstr ""
 
-#: menus/menu-welcome.php:1022
+#: menus/menu-welcome.php:1025
 msgid "Before the second"
 msgstr ""
 
-#: menus/menu-welcome.php:1024
+#: menus/menu-welcome.php:1027
 msgid ""
 "Check your main property page, if the buttons are in the incorrect place move them "
 "until they are in the correct place."
 msgstr ""
 
-#: menus/menu-welcome.php:1027
+#: menus/menu-welcome.php:1030
 msgid "After the second"
 msgstr ""
 
-#: menus/menu-welcome.php:1035
+#: menus/menu-welcome.php:1038
 msgid "Stuck getting your theme to work?"
 msgstr ""
 
-#: menus/menu-welcome.php:1036
+#: menus/menu-welcome.php:1039
 msgid ""
 "Not all themes follow modern WordPress coding standards and these may take a little "
 "more time and experience to get working. If you just can not get it to work, visit"
 msgstr ""
 
-#: menus/menu-welcome.php:1036
+#: menus/menu-welcome.php:1039
 msgid "premium support"
 msgstr ""
 
-#: menus/menu-welcome.php:1036
+#: menus/menu-welcome.php:1039
 msgid "and fill out a theme support request."
 msgstr ""
 
-#: menus/menu-welcome.php:1038
+#: menus/menu-welcome.php:1041
 msgid ""
 "If the theme is available in the WordPress.org theme directory let us know the theme "
 "name and URL where we can download it in your support ticket. If its a premium theme "
@@ -4058,60 +4070,60 @@ msgid ""
 "download link to it on a file sharing site like Dropbox."
 msgstr ""
 
-#: menus/menu-welcome.php:1040
+#: menus/menu-welcome.php:1043
 msgid "Need Help?"
 msgstr ""
 
-#: menus/menu-welcome.php:1044
+#: menus/menu-welcome.php:1047
 msgid "Premium Support"
 msgstr ""
 
-#: menus/menu-welcome.php:1045
+#: menus/menu-welcome.php:1048
 #, php-format
 msgid ""
 "We do our best to provide the best support we can. If you encounter a problem or have "
 "a question, post a question in the <a href=\"%s\">support forums</a>."
 msgstr ""
 
-#: menus/menu-welcome.php:1049
+#: menus/menu-welcome.php:1052
 msgid "Need Even Faster Support?"
 msgstr ""
 
-#: menus/menu-welcome.php:1050
+#: menus/menu-welcome.php:1053
 msgid ""
 "<a href=\"http://easypropertylistings.com.au/support/pricing/\">Priority Support "
 "forums</a> are there for customers that need faster and/or more in-depth assistance."
 msgstr ""
 
-#: menus/menu-welcome.php:1054
+#: menus/menu-welcome.php:1057
 msgid "Documentation and Short Codes"
 msgstr ""
 
-#: menus/menu-welcome.php:1055
+#: menus/menu-welcome.php:1058
 msgid "Read the"
 msgstr ""
 
-#: menus/menu-welcome.php:1055
+#: menus/menu-welcome.php:1058
 msgid "documentation"
 msgstr ""
 
-#: menus/menu-welcome.php:1055
+#: menus/menu-welcome.php:1058
 msgid " and instructions on how to use the included"
 msgstr ""
 
-#: menus/menu-welcome.php:1055
+#: menus/menu-welcome.php:1058
 msgid "shortcodes"
 msgstr ""
 
-#: menus/menu-welcome.php:1064
+#: menus/menu-welcome.php:1067
 msgid "Stay Up to Date"
 msgstr ""
 
-#: menus/menu-welcome.php:1065
+#: menus/menu-welcome.php:1068
 msgid "Get Notified of Extension Releases"
 msgstr ""
 
-#: menus/menu-welcome.php:1066
+#: menus/menu-welcome.php:1069
 msgid ""
 "New extensions that make Easy Property Listings even more powerful are released "
 "nearly every single week. Subscribe to the newsletter to stay up to date with our "
@@ -4119,25 +4131,25 @@ msgid ""
 "a> to ensure you do not miss a release!"
 msgstr ""
 
-#: menus/menu-welcome.php:1068
+#: menus/menu-welcome.php:1071
 msgid "Get Alerted About New Tutorials"
 msgstr ""
 
-#: menus/menu-welcome.php:1069
+#: menus/menu-welcome.php:1072
 msgid ""
 "<a href=\"http://eepurl.com/TRO9f\" target=\"_blank\">Sign up now</a> to hear about "
 "the latest tutorial releases that explain how to take Easy Property Listings further."
 msgstr ""
 
-#: menus/menu-welcome.php:1073
+#: menus/menu-welcome.php:1076
 msgid "Extend With Extensions"
 msgstr ""
 
-#: menus/menu-welcome.php:1074
+#: menus/menu-welcome.php:1077
 msgid "18 Extensions and many more coming"
 msgstr ""
 
-#: menus/menu-welcome.php:1075
+#: menus/menu-welcome.php:1078
 msgid ""
 "Add-on plug ins are available that greatly extend the default functionality of Easy "
 "Property Listings. There are extensions for Listing Sliders, Brochures, Advanced "
@@ -4145,27 +4157,27 @@ msgid ""
 "Location Profiles, and many, many more."
 msgstr ""
 
-#: menus/menu-welcome.php:1077
+#: menus/menu-welcome.php:1080
 msgid "Visit the Extension Store"
 msgstr ""
 
-#: menus/menu-welcome.php:1078
+#: menus/menu-welcome.php:1081
 msgid "The Extensions store"
 msgstr ""
 
-#: menus/menu-welcome.php:1078
+#: menus/menu-welcome.php:1081
 msgid ""
 "has a list of all available extensions to make your real estate website even better."
 msgstr ""
 
-#: menus/menu-welcome.php:1103
+#: menus/menu-welcome.php:1106
 msgid ""
 "Easy Property Listings is created by a worldwide team of developers who aim to "
 "provide the #1 property listings platform for managing your real estate business "
 "through WordPress."
 msgstr ""
 
-#: menus/menu-welcome.php:1130
+#: menus/menu-welcome.php:1133
 #, php-format
 msgid "View %s"
 msgstr ""

--- a/lib/menus/menu-welcome.php
+++ b/lib/menus/menu-welcome.php
@@ -273,6 +273,9 @@ class EPL_Welcome {
 					<h4><?php _e( 'Version 2.2.5', 'epl' );?></h4>
 					<ul>
 						<li><?php _e( 'Fix: Widget construct fixes for WordPress 4.3.', 'epl' );?></li>
+						<li><?php _e( 'Tweak: Un-install function.', 'epl' );?></li>
+						<li><?php _e( 'Tweak: Plugin page link to settings.', 'epl' );?></li>
+						<li><?php _e( 'Tweak: Languages updated.', 'epl' );?></li>
 					</ul>
 				
 					<h4><?php _e( 'Version 2.2.4', 'epl' );?></h4>

--- a/lib/menus/menu-welcome.php
+++ b/lib/menus/menu-welcome.php
@@ -270,6 +270,11 @@ class EPL_Welcome {
 			
 				<div class="feature-section">
 				
+					<h4><?php _e( 'Version 2.2.5', 'epl' );?></h4>
+					<ul>
+						<li><?php _e( 'Fix: Widget construct fixes for WordPress 4.3.', 'epl' );?></li>
+					</ul>
+				
 					<h4><?php _e( 'Version 2.2.4', 'epl' );?></h4>
 					<ul>
 						<li><?php _e( 'Tweak: Improvements to Commercial/Commercial Land/Business pricing when set to Lease type to display free form price text.', 'epl' );?></li>

--- a/lib/widgets/widget-author.php
+++ b/lib/widgets/widget-author.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class EPL_Widget_Author extends WP_Widget {
 
 	function __construct() {
-		parent::WP_Widget( false, $name = __('EPL - Author', 'epl') );
+		parent::__construct( false, $name = __('EPL - Author', 'epl') );
 	}
 
 	function widget($args, $instance) {

--- a/lib/widgets/widget-listing-gallery.php
+++ b/lib/widgets/widget-listing-gallery.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class EPL_Widget_Property_Gallery extends WP_Widget {
 
 	function __construct() {
-		parent::WP_Widget( false, $name = __('EPL - Listing Gallery', 'epl') );
+		parent::__construct( false, $name = __('EPL - Listing Gallery', 'epl') );
 	}
 
 	function widget($args, $instance) {

--- a/lib/widgets/widget-listing-search.php
+++ b/lib/widgets/widget-listing-search.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class EPL_Widget_Property_Search extends WP_Widget {
 
 	function __construct() {
-		parent::WP_Widget( false, $name = __('EPL - Listing Search', 'epl') );
+		parent::__construct( false, $name = __('EPL - Listing Search', 'epl') );
 	}
 
 	function widget($args, $instance) {

--- a/lib/widgets/widget-listing.php
+++ b/lib/widgets/widget-listing.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class EPL_Widget_Recent_Property extends WP_Widget {
 
 	function __construct() {
-		parent::WP_Widget( false, $name = __('EPL - Listing', 'epl') );
+		parent::__construct( false, $name = __('EPL - Listing', 'epl') );
 	}
 
 	function widget($args, $instance) {	

--- a/readme.txt
+++ b/readme.txt
@@ -230,6 +230,9 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 = 2.2.5 August 20, 2015 =
 
 * Fix: Widget construct fixes for WordPress 4.3.
+* Tweak: Un-install function.
+* Tweak: Plugin page link to settings.
+* Tweak: Languages updated.
 
 = 2.2.4 August 05, 2015 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,9 +5,9 @@ Contributors: mervb1
 Donate link: http://easypropertylistings.com.au/support-the-site/
 Tags: real estate, property, listings, rental, commercial, business, rural, land, residential, property listings, property management, realtor, broker, australia, wp-property, wp property, wp rentals, wp-realestate, wp real estate, multisite, property, Merv Barrett, real estate connected
 Requires at least: 3.3
-Tested up to: 4.2.3
+Tested up to: 4.3
 
-Stable Tag: 2.2.4
+Stable Tag: 2.2.5
 
 License: GNU Version 2 or Any Later Version
 
@@ -19,11 +19,15 @@ Easy Property Listing is one of the most dynamic and feature rich Real Estate pl
 
 An easy to use plugin that provides the needed functions to configure a dynamic real estate website in minutes. Packed with advanced features, shortcodes and templates letting you create real estate websites fast.
 
-> <strong>Theme Setup</strong><br>
-> To get the best result from Easy Property Listings on your real estate website you need to [configure your theme](http://easypropertylistings.com.au/docs/setup-wordpress-theme-easy-property-listings-2-0/) using some copy and paste. This will enable a better display and will make the plugin look great on any WordPress theme. If you need theme setup assistance first check the [theme support forum](http://easypropertylistings.com.au/support/forum/theme-support/) as many templates are already available.
+> <strong>Theme Setup - Are you feeling lucky?</strong><br>
+> The latest release of Easy Property Listings includes a theme compatibility mode that works great for most themes. Once you have activated the plugin visit Dashboard > Easy Property Listings > Settings > Theme Setup. Before you enable the theme compatibility mode, add a listing and preview. If it looks great, you are good to go, however if your listing is too wide or your sidebar is in the wrong place activate Theme Compatibility mode. Next adjust the 
+Theme Setup: Featured Images to adjust how your featured images appear. If you see two featured images play with the settings until it looks great.
+
+> <strong>Manual Theme Setup</strong><br>
+> To get the best result from Easy Property Listings on your real estate website you need to either manually [configure your theme](http://easypropertylistings.com.au/docs/setup-wordpress-theme-easy-property-listings-2-0/) using some copy and paste which gives you greater control over your listings. This will enable a better display and will make the plugin look great on any WordPress theme. If you need theme setup assistance first check the [theme support forum](http://easypropertylistings.com.au/support/forum/theme-support/) as we have already created many templates for popular WordPress themes.
 
 > <strong>Premium Support</strong><br>
-> The Easy Property Listings team does not provide support for the real estate plugin on the WordPress.org forums. One on one forum support is available to people who bought [Premium support](http://easypropertylistings.com.au/support/pricing/?utm_source=readme&utm_medium=description_tab&utm_content=premium_support&utm_campaign=wordpressorg) only. Note that Premium Support also includes the [Advanced Mapping](http://easypropertylistings.com.au/extensions/advanced-mapping/?utm_source=readme&utm_medium=description_tab&utm_content=extensions_link&utm_campaign=wordpressorg) extension and theme setup assistance so it might be well worth your investment!
+> The Easy Property Listings team does not provide support for the real estate plugin on the WordPress.org forums. One on one forum support is available to people who bought [Premium support](http://easypropertylistings.com.au/support/pricing/?utm_source=readme&utm_medium=description_tab&utm_content=premium_support&utm_campaign=wordpressorg) only.
 
 You should also check out the Local SEO, News SEO and Video SEO extensions to WordPress SEO, these of course come with support too.
 
@@ -102,17 +106,34 @@ More information at [Easy Property Listings.com.au](http://easypropertylistings.
 
 **Follow this plugin on [GitHub](https://github.com/easypropertylistings/Easy-Property-Listings)**
 
-**Advanced Mapping**
+<strong>Advanced Mapping</strong><br>
+[Advanced Map](http://easypropertylistings.com.au/extensions/advanced-mapping/?utm_source=readme&utm_medium=description_tab&utm_content=extensions_link&utm_campaign=epl_extension_advanced_map) Create a beautiful map showcasing your listings with a powerful shortcode.
 
-[Advanced Map](http://easypropertylistings.com.au/extensions/advanced-mapping/) Create a beautiful map showcasing your listings with a powerful shortcode.
+<strong>Brochures and Stock List Extension</strong><br>
+With the [brochures](http://easypropertylistings.com.au/extensions/brochures/?utm_source=readme&utm_medium=description_tab&utm_content=extensions_link&utm_campaign=epl_extension_brochures) extension for Easy Property Listings you can create printable brochures and stock lists for your listings. There are several options to control the brochure styles and templates. Or create your own!
 
-**Listing Alerts**
+<strong>Frontend Submissions</strong><br>
+[Frontend Submissions](http://easypropertylistings.com.au/extensions/frontend-submissions/?utm_source=readme&utm_medium=description_tab&utm_content=extensions_link&utm_campaign=epl_extension_frontend_submissions) Frontend Submissions provides a the ability to submit listings via a frontend form for review using a shortcode. They can also edit submitted listings from the frontend of your website.
 
-[Listing Alerts](http://easypropertylistings.com.au/extensions/listing-alerts/) Schedule email alerts to subscribers with HTML email support and customisable messages.
+<strong>Listing Alerts</strong><br>
+[Listing Alerts](http://easypropertylistings.com.au/extensions/listing-alerts/?utm_source=readme&utm_medium=description_tab&utm_content=extensions_link&utm_campaign=epl_extension_listing_alerts) Schedule email alerts to subscribers with HTML email support and customisable messages.
 
-**Link listings with other types of content**
+<strong>Location Profiles</strong><br>
+[Location Profiles](http://easypropertylistings.com.au/extensions/location-profiles/?utm_source=readme&utm_medium=description_tab&utm_content=extensions_link&utm_campaign=epl_extension_location_profiles) With this plugin, you can add detailed suburb, city or neighbourhood profiles automatically to your listings in that location.
 
-With add-ons for [Listing Templates](http://easypropertylistings.com.au/extensions/listing-templates/), [Suburb/City Profiles](http://easypropertylistings.com.au/extensions/suburb-profiles/), [Testimonials](http://easypropertylistings.com.au/extensions/testimonial-manager/), and [Staff Directory](http://easypropertylistings.com.au/extensions/staff-directory/), [Awards](http://easypropertylistings.com.au/extensions/awards/), [Business Directory](http://easypropertylistings.com.au/extensions/business-directory/), [FeedSync REAXML](http://easypropertylistings.com.au/extensions/feedsync/), and more, Easy Property Listings can enhance your listings by dynamically linking content and you offering opportunities to build a deep real estate website.
+<strong>Market Research</strong><br>
+[Market Research](http://easypropertylistings.com.au/extensions/market-research/?utm_source=readme&utm_medium=description_tab&utm_content=extensions_link&utm_campaign=epl_extension_market_research). With the Market Research extension for Easy Property Listings you can import property sales data and dynamically display it on your listings in a matching location.
+
+<strong>Sliders</strong><br>
+[Sliders](http://easypropertylistings.com.au/extensions/sliders/?utm_source=readme&utm_medium=description_tab&utm_content=extensions_link&utm_campaign=epl_extension_slider) The Sliders extension allows you to effortlessly create beautiful listing galleries that include numerous options and are fully responsive.
+
+<strong>Staff/Agent Directory</strong><br>
+[Staff/Agent Directory](http://easypropertylistings.com.au/extensions/staff-directory/?utm_source=readme&utm_medium=description_tab&utm_content=extensions_link&utm_campaign=epl_extension_staff_directory) Give your real estate agents and staff an enhanced author profile on your listings and manage staff members with this extension.
+
+<strong>Testimonial Manager</strong><br>
+[Testimonial Manager](http://easypropertylistings.com.au/extensions/testimonial-manager/?utm_source=readme&utm_medium=description_tab&utm_content=extensions_link&utm_campaign=epl_extension_testimonial_manager) Testimonials can be an effective way to get more listings. They add credibility and builds trust. With this plugin, quickly add testimonials and have them link with properties in specific locations.
+
+[Many more extensions can be found here](http://easypropertylistings.com.au/?utm_source=readme&utm_medium=description_tab&utm_content=extensions_link&utm_campaign=epl_extensions).
 
 **Languages**
 
@@ -140,17 +161,33 @@ Would you like to help translate the plugin into more languages? [Join our Trans
 2. Go to Easy Property Listings > Settings and enable your listing types and press save.
 3. Customise your labels, tweak the display, all in minutes from Easy Property Listings > Setting page.
 4. Add a listing as you would a post. Check the help guide inside the plugin. Dashboard > Easy Property Listings > Help. These instructions are also accessible to authors.
-5. Create blank pages for each listing type you enable so you can easily add the archive page to your WordPress menus
-6. Insert short codes, add widgets, read the guide.
-7. For detailed setup instructions, visit the official [Documentation](http://easypropertylistings.com.au/documentation/) page.
+5. Create blank pages for each listing type you enable so you can easily add the archive page to your WordPress menus. There are detailed instructions which you can access from your Dashboard > Easy Property Listings > Help & Help > Getting Started
+6. The latest release of Easy Property Listings includes a theme compatibility mode that works great for most themes. Once you have activated the plugin visit Dashboard > Easy Property Listings > Settings > Theme Setup. Before you enable the theme compatibility mode, add a listing and preview. If it looks great, you are good to go, however if your listing is too wide or your sidebar is in the wrong place activate Theme Compatibility mode. Next adjust the 
+Theme Setup: Featured Images to adjust how your featured images appear. If you see two featured images play with the settings until it looks great.
+7. Add widgets, shortcodes and listings.
+8. Have a cup of coffee as you'll be amazed at how quickly and easily you created an advanced Real Estate listing website.
+9. For detailed setup instructions, visit the official [Documentation](http://easypropertylistings.com.au/documentation/) page.
+10. Visit the [Extension Store](http://easypropertylistings.com.au/?utm_source=readme&utm_medium=description_tab&utm_content=extensions_link&utm_campaign=epl_extensions) to further enhance your real estate website with cool SEO focused tools.
 
 == Frequently Asked Questions ==
+
+= Will this work for bigger companies with multiple agents? =
+
+Absolutely, Easy Property Listings is built from the ground up for scale, speed and thousands of listings. When you want dynamic agent and staff profiles we recommend the [Staff/Agent Directory](http://easypropertylistings.com.au/extensions/staff-directory/?utm_source=readme&utm_medium=description_tab&utm_content=extensions_link&utm_campaign=epl_extension_staff_directory) extension. This allows you to quickly set-up multiple agent and staff members and automatically display all the agents listings, post activity and use a featured image instead of the default Gravatar.
+
+= We want to display less or more info on the archive and single listing views, how can we create a unique customised look? =
+
+You can use the Easy Property Listings template loading system that lets you place all the plugin templates inside themes/YOUR_THEME/easypropertylistings/ folder and edit everything. You can [read more about how to do that here](http://easypropertylistings.com.au/docs/create-custom-theme-templates-using-included-hooks/?utm_source=readme&utm_medium=faq_tab&utm_content=templates&utm_campaign=epl_documentation).
 
 = How do I setup my WordPress theme to work with Easy Property Listings 2.0 =
 
 In order for correct integration with your WordPress theme please follow these instructions [WordPress Theme configuration instructions](http://easypropertylistings.com.au/section/theming/).
 
 These instructions are also located inside the plugin. Visit Dashboard > Easy Property Listings > Help > Getting Started > Setup your theme to work with the plugin
+
+= Do I need to know code like php or advanced CSS? =
+
+We built this plugin from the perspective of a real estate agent as that's what I used to do. We want this to be an easy to install and use plugin so you can focus on listing/selling and leasing property. No advanced coding knowledge needed, activate the property types and add listings, so no matter your experience it will work for you.
 
 = How do I Show My List of Listings? =
 
@@ -189,6 +226,10 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 6. Home open shortcode and Multi Author widget
 
 == Changelog ==
+
+= 2.2.5 August 20, 2015 =
+
+* Fix: Widget construct fixes for WordPress 4.3.
 
 = 2.2.4 August 05, 2015 =
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -17,7 +17,7 @@ include_once( 'easy-property-listings.php' );
 
 global $wpdb, $wp_roles;
 
-if( epl_get_option( 'uninstall_on_delete' ) ) {
+if( epl_get_option( 'uninstall_on_delete' ) == 1 ) {
 
 	/** Delete All the Custom Post Types */
 	$epl_taxonomies = array( 'location', 'tax_feature', 'tax_business_listing', );


### PR DESCRIPTION
* Fix: Widget construct fixes for WordPress 4.3.
* Tweak: Un-install function.
* Tweak: Plugin page link to settings.
* Tweak: Languages updated.