### PR TITLE
Easy Property Listings Official Release 2.2.6

### DIFF
--- a/easy-property-listings.php
+++ b/easy-property-listings.php
@@ -5,7 +5,7 @@
  * Description:  Fast. Flexible. Forward-thinking solution for real estate agents using WordPress. Easy Property Listing is one of the most dynamic and feature rich Real Estate plugin for WordPress available on the market today. Built for scale, lead generation and works with any theme!
  * Author: Merv Barrett
  * Author URI: http://www.realestateconnected.com.au
- * Version: 2.2.5
+ * Version: 2.2.6
  * Text Domain: epl
  * Domain Path: languages
  *
@@ -25,7 +25,7 @@
  * @package EPL
  * @category Core
  * @author Merv Barrett
- * @version 2.2.5
+ * @version 2.2.6
  */
  
 // Exit if accessed directly
@@ -83,7 +83,7 @@ if ( ! class_exists( 'Easy_Property_Listings' ) ) :
 		public function setup_constants() {		
 			// Plugin version
 			if ( ! defined( 'EPL_PROPERTY_VER' ) ) {
-				define( 'EPL_PROPERTY_VER', '2.2.5' );
+				define( 'EPL_PROPERTY_VER', '2.2.6' );
 			}
 			// Plugin DB version
 			if ( ! defined( 'EPL_PROPERTY_DB_VER' ) ) {

--- a/lib/includes/EPL_License_Handler.php
+++ b/lib/includes/EPL_License_Handler.php
@@ -23,7 +23,7 @@ if ( ! class_exists( 'EPL_License' ) ) :
 		private $item_shortname;
 		private $version;
 		private $author;
-		private $api_url = 'http://easypropertylistings.com.au';
+		private $api_url = 'https://easypropertylistings.com.au/edd-sl-api/';
 
 		/**
 		 * Class constructor

--- a/lib/menus/menu-welcome.php
+++ b/lib/menus/menu-welcome.php
@@ -272,7 +272,7 @@ class EPL_Welcome {
 				
 					<h4><?php _e( 'Version 2.2.6', 'epl' );?></h4>
 					<ul>
-						<li><?php _e( 'Fix: Updated extension licensing updater to use https.', 'epl' );?></li>
+						<li><?php _e( 'Fix: Updated extension licensing updater to use https. Update required in order to be able to auto-update your extensions as Easy Property Listings has moved to https.', 'epl' );?></li>
 					</ul>
 				
 					<h4><?php _e( 'Version 2.2.5', 'epl' );?></h4>

--- a/lib/menus/menu-welcome.php
+++ b/lib/menus/menu-welcome.php
@@ -270,6 +270,11 @@ class EPL_Welcome {
 			
 				<div class="feature-section">
 				
+					<h4><?php _e( 'Version 2.2.6', 'epl' );?></h4>
+					<ul>
+						<li><?php _e( 'Fix: Updated extension licensing updater to use https.', 'epl' );?></li>
+					</ul>
+				
 					<h4><?php _e( 'Version 2.2.5', 'epl' );?></h4>
 					<ul>
 						<li><?php _e( 'Fix: Widget construct fixes for WordPress 4.3.', 'epl' );?></li>

--- a/readme.txt
+++ b/readme.txt
@@ -229,7 +229,7 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 
 = 2.2.6 August 22, 2015 =
 
-* Fix: Updated extension licensing updater to use https.
+* Fix: Updated extension licensing updater to use https. Update required in order to be able to auto-update your extensions as Easy Property Listings has moved to https.
 
 = 2.2.5 August 20, 2015 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: real estate, property, listings, rental, commercial, business, rural, land
 Requires at least: 3.3
 Tested up to: 4.3
 
-Stable Tag: 2.2.5
+Stable Tag: 2.2.6
 
 License: GNU Version 2 or Any Later Version
 
@@ -226,6 +226,10 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 6. Home open shortcode and Multi Author widget
 
 == Changelog ==
+
+= 2.2.6 August 22, 2015 =
+
+* Fix: Updated extension licensing updater to use https.
 
 = 2.2.5 August 20, 2015 =
 


### PR DESCRIPTION
Fix: Updated extension licensing updater to use https. Update required in order to be able to auto-update your extensions as Easy Property Listings has moved to https.