### PR TITLE
Fixing issue of don't showing address separator when address of prope…

### DIFF
--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -438,8 +438,10 @@ function epl_property_the_address() {
 		<?php 
 			if( $property->get_property_meta('property_com_display_suburb') != 'no' || $property->get_property_meta('property_address_display') == 'yes' ) { ?>
 				<span class="item-suburb"><?php echo $property->get_property_meta('property_address_suburb'); ?></span><?php
+				if ( strlen( trim( $property->get_property_meta( 'property_address_suburb' ) ) ) ) {
+					echo '<span class="item-seperator">' . $epl_property_address_seperator . '</span>';
+				}
 			}
-			echo '<span class="item-seperator">' . $epl_property_address_seperator . '</span>';
 		?>
 		<?php 
 			if( $property->get_epl_settings('epl_enable_city_field') == 'yes' ) { ?>


### PR DESCRIPTION
This commit will fix issue that Easy Property Listings shows address separator "," when address of the listing is empty and removes address separator when listing address is empty.