### PR TITLE
3.1.12 master

### DIFF
--- a/apigen.neon
+++ b/apigen.neon
@@ -21,7 +21,7 @@ charset: [UTF-8]
 main: EPL
 
 # title of generated documentation
-title: Easy Property Listings 3.1.11 Code Reference
+title: Easy Property Listings 3.1.12 Code Reference
 
 # base url used for sitemap (useful for public doc)
 baseUrl: http://docs.easypropertylistings.com.au/

--- a/easy-property-listings.php
+++ b/easy-property-listings.php
@@ -5,7 +5,7 @@
  * Description:  Fast. Flexible. Forward-thinking solution for real estate agents using WordPress. Easy Property Listing is one of the most dynamic and feature rich Real Estate plugin for WordPress available on the market today. Built for scale, contact generation and works with any theme!
  * Author: Merv Barrett
  * Author URI: http://www.realestateconnected.com.au/
- * Version: 3.1.11
+ * Version: 3.1.12
  * Text Domain: easy-property-listings
  * Domain Path: languages
  *
@@ -25,7 +25,7 @@
  * @package EPL
  * @category Core
  * @author Merv Barrett
- * @version 3.1.11
+ * @version 3.1.12
  */
 
 // Exit if accessed directly
@@ -93,7 +93,7 @@ if ( ! class_exists( 'Easy_Property_Listings' ) ) :
 		public function setup_constants() {
 			// Plugin version
 			if ( ! defined( 'EPL_PROPERTY_VER' ) ) {
-				define( 'EPL_PROPERTY_VER', '3.1.11' );
+				define( 'EPL_PROPERTY_VER', '3.1.12' );
 			}
 			// Plugin DB version
 			if ( ! defined( 'EPL_PROPERTY_DB_VER' ) ) {

--- a/languages/easy-property-listings.pot
+++ b/languages/easy-property-listings.pot
@@ -3,9 +3,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Easy Property Listings 3.1.11\n"
+"Project-Id-Version: Easy Property Listings 3.1.12\n"
 "Report-Msgid-Bugs-To: http://wordpress.org/support/plugin/easy-property-listings\n"
-"POT-Creation-Date: 2017-04-10 11:19+0800\n"
+"POT-Creation-Date: 2017-04-27 16:26+0800\n"
 "PO-Revision-Date: 2015-09-09 16:02+0800\n"
 "Last-Translator: Merv Barrett <admin@realestateconnected.com.au>\n"
 "Language-Team: Real Estate Connected <support@realestateconnected.com.au>\n"
@@ -31,7 +31,7 @@ msgstr ""
 #: lib/includes/admin/contacts/class-contact-table.php:64
 #: lib/includes/admin/contacts/class-contact-table.php:193
 #: lib/includes/class-epl-author-meta.php:80 lib/includes/functions.php:2044
-#: lib/includes/template-functions.php:1172 lib/post-types/post-type-contact.php:29
+#: lib/includes/template-functions.php:1241 lib/post-types/post-type-contact.php:29
 #: lib/post-types/post-type-contact.php:30
 msgid "Contact"
 msgstr ""
@@ -122,7 +122,6 @@ msgid "Read More"
 msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:311
-#: lib/includes/class-epl-property-meta.php:1113
 msgid "sqm"
 msgstr ""
 
@@ -174,8 +173,8 @@ msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:426
 #: lib/compatibility/listing-meta-compat.php:427
-#: lib/includes/class-epl-property-meta.php:560
-#: lib/includes/class-epl-property-meta.php:659
+#: lib/includes/class-epl-property-meta.php:602
+#: lib/includes/class-epl-property-meta.php:701
 msgid "TBA"
 msgstr ""
 
@@ -191,24 +190,24 @@ msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:597
 #: lib/compatibility/listing-meta-compat.php:599
-#: lib/includes/class-epl-property-meta.php:506
-#: lib/includes/class-epl-property-meta.php:508
+#: lib/includes/class-epl-property-meta.php:548
+#: lib/includes/class-epl-property-meta.php:550
 msgid "Inc. GST"
 msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:601
-#: lib/includes/class-epl-property-meta.php:510
+#: lib/includes/class-epl-property-meta.php:552
 msgid "GST"
 msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:613
 #: lib/compatibility/listing-meta-compat.php:614
 #: lib/compatibility/listing-meta-compat.php:615
-#: lib/includes/class-epl-property-meta.php:574
-#: lib/includes/class-epl-property-meta.php:577
-#: lib/includes/class-epl-property-meta.php:679
-#: lib/includes/class-epl-property-meta.php:687
-#: lib/includes/class-epl-property-meta.php:877 lib/meta-boxes/meta-boxes.php:53
+#: lib/includes/class-epl-property-meta.php:616
+#: lib/includes/class-epl-property-meta.php:619
+#: lib/includes/class-epl-property-meta.php:721
+#: lib/includes/class-epl-property-meta.php:729
+#: lib/includes/class-epl-property-meta.php:919 lib/meta-boxes/meta-boxes.php:53
 msgid "For Sale"
 msgstr ""
 
@@ -218,17 +217,17 @@ msgstr ""
 #: lib/compatibility/listing-meta-compat.php:638
 #: lib/compatibility/listing-meta-compat.php:639
 #: lib/compatibility/listing-meta-compat.php:640
-#: lib/includes/class-epl-property-meta.php:585
-#: lib/includes/class-epl-property-meta.php:587
-#: lib/includes/class-epl-property-meta.php:589
-#: lib/includes/class-epl-property-meta.php:592
-#: lib/includes/class-epl-property-meta.php:699
-#: lib/includes/class-epl-property-meta.php:704
-#: lib/includes/class-epl-property-meta.php:711
-#: lib/includes/class-epl-property-meta.php:729
-#: lib/includes/class-epl-property-meta.php:736
-#: lib/includes/class-epl-property-meta.php:890
-#: lib/includes/class-epl-property-meta.php:892
+#: lib/includes/class-epl-property-meta.php:627
+#: lib/includes/class-epl-property-meta.php:629
+#: lib/includes/class-epl-property-meta.php:631
+#: lib/includes/class-epl-property-meta.php:634
+#: lib/includes/class-epl-property-meta.php:741
+#: lib/includes/class-epl-property-meta.php:746
+#: lib/includes/class-epl-property-meta.php:753
+#: lib/includes/class-epl-property-meta.php:771
+#: lib/includes/class-epl-property-meta.php:778
+#: lib/includes/class-epl-property-meta.php:932
+#: lib/includes/class-epl-property-meta.php:934
 msgid "For Lease"
 msgstr ""
 
@@ -238,38 +237,38 @@ msgstr ""
 #: lib/compatibility/listing-meta-compat.php:638
 #: lib/compatibility/listing-meta-compat.php:639
 #: lib/compatibility/listing-meta-compat.php:640
-#: lib/includes/class-epl-property-meta.php:664
-#: lib/includes/class-epl-property-meta.php:873 lib/includes/functions.php:583
+#: lib/includes/class-epl-property-meta.php:706
+#: lib/includes/class-epl-property-meta.php:915 lib/includes/functions.php:583
 msgid "P.A."
 msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:662
-#: lib/includes/class-epl-property-meta.php:939 lib/meta-boxes/meta-boxes.php:295
+#: lib/includes/class-epl-property-meta.php:967 lib/meta-boxes/meta-boxes.php:295
 msgid "Bedrooms"
 msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:663
 #: lib/compatibility/listing-meta-compat.php:664
-#: lib/includes/class-epl-property-meta.php:940
-#: lib/includes/class-epl-property-meta.php:941
+#: lib/includes/class-epl-property-meta.php:968
+#: lib/includes/class-epl-property-meta.php:969
 msgid "bed"
 msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:667
-#: lib/includes/class-epl-property-meta.php:956 lib/meta-boxes/meta-boxes.php:302
+#: lib/includes/class-epl-property-meta.php:984 lib/meta-boxes/meta-boxes.php:302
 #: lib/widgets/widget-functions.php:475
 msgid "Bathrooms"
 msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:668
 #: lib/compatibility/listing-meta-compat.php:669
-#: lib/includes/class-epl-property-meta.php:957
-#: lib/includes/class-epl-property-meta.php:958
+#: lib/includes/class-epl-property-meta.php:985
+#: lib/includes/class-epl-property-meta.php:986
 msgid "bath"
 msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:672
-#: lib/includes/class-epl-property-meta.php:973 lib/meta-boxes/meta-boxes.php:309
+#: lib/includes/class-epl-property-meta.php:1001 lib/meta-boxes/meta-boxes.php:309
 #: lib/post-types/post-types.php:260 lib/widgets/widget-functions.php:141
 #: lib/widgets/widget-functions.php:494
 msgid "Rooms"
@@ -277,19 +276,19 @@ msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:673
 #: lib/compatibility/listing-meta-compat.php:674
-#: lib/includes/class-epl-property-meta.php:974
-#: lib/includes/class-epl-property-meta.php:975
+#: lib/includes/class-epl-property-meta.php:1002
+#: lib/includes/class-epl-property-meta.php:1003
 msgid "rooms"
 msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:677
-#: lib/includes/class-epl-property-meta.php:997
-#: lib/includes/class-epl-property-meta.php:998
+#: lib/includes/class-epl-property-meta.php:1025
+#: lib/includes/class-epl-property-meta.php:1026
 msgid "Parking Spaces"
 msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:680
-#: lib/includes/class-epl-property-meta.php:1053 lib/meta-boxes/meta-boxes.php:377
+#: lib/includes/class-epl-property-meta.php:1081 lib/meta-boxes/meta-boxes.php:377
 #: lib/widgets/widget-functions.php:646
 msgid "Air Conditioning"
 msgstr ""
@@ -300,7 +299,7 @@ msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:684
 #: lib/compatibility/listing-meta-compat.php:685
-#: lib/includes/class-epl-property-meta.php:1073 lib/meta-boxes/meta-boxes.php:368
+#: lib/includes/class-epl-property-meta.php:1101 lib/meta-boxes/meta-boxes.php:368
 #: lib/widgets/widget-functions.php:661
 msgid "Pool"
 msgstr ""
@@ -310,7 +309,7 @@ msgid "Toilet"
 msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:694
-#: lib/includes/class-epl-property-meta.php:1164 lib/meta-boxes/meta-boxes.php:358
+#: lib/includes/class-epl-property-meta.php:1195 lib/meta-boxes/meta-boxes.php:358
 msgid "New Construction"
 msgstr ""
 
@@ -327,12 +326,12 @@ msgid "Carport"
 msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:708
-#: lib/includes/class-epl-property-meta.php:1119
+#: lib/includes/class-epl-property-meta.php:1150
 msgid "Land is"
 msgstr ""
 
 #: lib/compatibility/listing-meta-compat.php:711
-#: lib/includes/class-epl-property-meta.php:1144
+#: lib/includes/class-epl-property-meta.php:1177
 msgid "Floor Area is"
 msgstr ""
 
@@ -774,7 +773,7 @@ msgstr ""
 
 #: lib/includes/admin/contacts/contact-actions.php:1016
 #: lib/includes/admin/contacts/contacts.php:425 lib/includes/admin/help-single.php:44
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1283
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1302
 #: lib/includes/admin/menus/menu-help.php:126 lib/widgets/widget-functions.php:25
 #: lib/widgets/widget-functions.php:1192 lib/widgets/widget-listing.php:225
 msgid "Title"
@@ -1377,15 +1376,15 @@ msgid "Credits"
 msgstr ""
 
 #: lib/includes/admin/menus/class-epl-menu-welcome.php:157
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1180
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1478
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1199
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1497
 #, php-format
 msgid "Welcome to Easy Property Listings %s"
 msgstr ""
 
 #: lib/includes/admin/menus/class-epl-menu-welcome.php:158
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1181
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1479
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1200
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1498
 #, php-format
 msgid ""
 "Thank you for updating to the latest version! Easy Property Listings %s is ready to "
@@ -1393,24 +1392,24 @@ msgid ""
 msgstr ""
 
 #: lib/includes/admin/menus/class-epl-menu-welcome.php:159
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1182
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1480
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1201
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1499
 #, php-format
 msgid "Version %s"
 msgstr ""
 
 #: lib/includes/admin/menus/class-epl-menu-welcome.php:164
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1451
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1470
 msgid "Location Profiles"
 msgstr ""
 
 #: lib/includes/admin/menus/class-epl-menu-welcome.php:165
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1449
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1468
 msgid "Testimonial Manager"
 msgstr ""
 
 #: lib/includes/admin/menus/class-epl-menu-welcome.php:166
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1448
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1467
 msgid "Advanced Mapping"
 msgstr ""
 
@@ -1537,189 +1536,257 @@ msgid "Many more changes have been made which are noted in the Change Log below.
 msgstr ""
 
 #: lib/includes/admin/menus/class-epl-menu-welcome.php:248
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1206
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1225
 #: lib/includes/admin/menus/menu-help.php:39
 msgid "Full Change Log"
 msgstr ""
 
 #: lib/includes/admin/menus/class-epl-menu-welcome.php:252
-msgid "Version 3.1.11"
+msgid "Version 3.1.12"
 msgstr ""
 
 #: lib/includes/admin/menus/class-epl-menu-welcome.php:255
-msgid "Fix: Property ID search in admin."
+msgid "New: Filter epl_property_land_area_unit_label for Land Unit Label Filter."
 msgstr ""
 
 #: lib/includes/admin/menus/class-epl-menu-welcome.php:256
-msgid "New: Brazilian Portuguese Translation thanks to Dijo."
+msgid ""
+"New: Filter epl_property_building_area_unit_label for Building Unit Label Filter."
 msgstr ""
 
 #: lib/includes/admin/menus/class-epl-menu-welcome.php:257
-msgid "New: Added epl_button_target_floorplan filter."
+msgid "New: Filter epl_the_property_feature_list_before before the features list."
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:258
+msgid ""
+"New: Filter epl_the_property_feature_list_before_common_features before the common "
+"features list."
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:259
+msgid ""
+"New: Filter epl_the_property_feature_list_before_additional_features before the "
+"additional features list."
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:260
+msgid ""
+"New: Filter epl_the_property_feature_list_after for after the output of the features "
+"list."
 msgstr ""
 
 #: lib/includes/admin/menus/class-epl-menu-welcome.php:261
-msgid "Version 3.1.10"
+msgid "Tweak: Property, Rural, Commercial Category output to secondary heading."
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:262
+msgid "Tweak: Altered land sqm output to m2."
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:263
+msgid "Tweak: Shortcode [listing_auction] now only displays auction listings."
 msgstr ""
 
 #: lib/includes/admin/menus/class-epl-menu-welcome.php:264
-msgid "New: Filter added epl_ical_args for iCal output."
+msgid "Fix: Property Category now outputs to feature list."
 msgstr ""
 
 #: lib/includes/admin/menus/class-epl-menu-welcome.php:265
+msgid "Fix: Rural Category now outputs to feature list."
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:266
+msgid "Fix: Commercial Category now outputs to feature list."
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:267
+msgid ""
+"Fix: Empty Commercial Features heading no longer outputs heading if values are empty."
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:268
+msgid "Fix: Empty Rural Features heading no longer outputs heading if values are empty."
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:271
+msgid "Version 3.1.11"
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:274
+msgid "Fix: Property ID search in admin."
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:275
+msgid "New: Brazilian Portuguese Translation thanks to Dijo."
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:276
+msgid "New: Added epl_button_target_floorplan filter."
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:280
+msgid "Version 3.1.10"
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:283
+msgid "New: Filter added epl_ical_args for iCal output."
+msgstr ""
+
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:284
 msgid ""
 "Tweak: Ability to search by property ID when managing listings from the Dashboard."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:266
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:285
 msgid "Tweak: Added Sortable column Unique ID."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:269
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:288
 msgid "Version 3.1.9"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:272
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:291
 msgid "Tweak: Allowed Authors and Contributors to access help screens."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:275
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:294
 msgid "Version 3.1.8"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:278
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:297
 msgid ""
 "Fix: Corrected Listing not found filters used in archive templates with a new "
 "epl_property_search_not_found hook."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:279
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:298
 msgid "Tweak: Translations updated."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:282
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:301
 msgid "Version 3.1.7"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:285
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:304
 msgid ""
 "New: Added epl_template_class to templates and added its context for Listing "
 "Templates extension."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:286
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:305
 msgid "New: Auction Date processing function for import scripts."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:287
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:306
 msgid "New: REAXML convert date/time to adjust for timezone for import scripts."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:288
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:307
 msgid "Tweak: Wording for delete settings adjusted to reflect radio option."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:289
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:308
 msgid "Fix: Corrected missing Property Features title and filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:292
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:311
 msgid "Version 3.1.6"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:295
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:314
 msgid "New: Hierarchical Features Taxonomy EPL_FEATURES_HIERARCHICAL Constant."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:296
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:315
 msgid ""
 "New: Filter for Commercial For Sale and Lease label "
 "epl_commercial_for_sale_and_lease_label when both option selected."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:297
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:316
 msgid ""
 "New: Added filters for shortcodes to adjust no results messages. Filters "
 "epl_shortcode_results_message_title_open for [listing_open] shortcode and "
 "epl_shortcode_results_message_title for all other shortcodes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:298
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:317
 msgid ""
 "Tweak: Additional case values for importing additional features now accepts YES, yes, "
 "Y, y, on, NO, no, N, n, off."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:299
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:318
 msgid "New: Common features filter epl_property_common_features_list added."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:300
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:319
 msgid ""
 "Tweak: Corrected spelling of meta box group ids for commercial_features and "
 "files_n_links."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:301
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:320
 msgid ""
 "Tweak: Author widget will no longer display if hide author box on a listing is ticked."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:302
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:321
 msgid "Tweak: Filter for epl template class."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:303
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:322
 msgid "Fix: Commercial listing lease price text display when both option selected."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:304
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:323
 msgid ""
 "Fix: Property Features title filter epl_property_sub_title_property_features enabling "
 "title modification."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:305
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:324
 msgid "Fix: Post type archive called incorrectly in some cases."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:306
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:325
 msgid "Fix: PHP 7.1 support."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:307
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:326
 msgid "Fix: Class adjustment for taxonomy search."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:310
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:329
 msgid "Version 3.1.5"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:313
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:332
 msgid ""
 "New: Added a Google Maps API key notification to Easy Property Listings > Settings "
 "when no key is set."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:314
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:333
 msgid "Tweak: Internal shortcode option documentation."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:315
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:334
 msgid ""
 "Fix: Shortcode offset breaking pagination. Note when using offset, pagination is "
 "disabled: [listing] , [listing_category], [listing_feature], [listing_location]"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:316
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:335
 msgid "Fix: Corrected the default option when using select fields."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:319
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:338
 msgid "Version 3.1.4"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:322
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:341
 msgid ""
 "New: Added offset option to the following shortcodes that allows you to place "
 "multiple shortcodes on a single page and prevent displaying duplicate listings. Added "
@@ -1727,1884 +1794,1884 @@ msgid ""
 "[listing_location]"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:323
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:342
 msgid "Tweak: Optimisations to secondary author display by removing duplicate code."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:324
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:343
 msgid ""
 "Tweak: Improvements to extension license updater and notifications on license status."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:325
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:344
 msgid "Tweak: Performance improvements to admin functions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:326
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:345
 msgid "Tweak: Translations adjustment to load textdomain after all plugins initialised."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:329
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:348
 msgid "Version 3.1.3"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:332
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:351
 msgid "Fix: Contact linking when editing listings with invalid contact ID."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:333
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:352
 msgid "Fix: Shortcode sorting for Current/Sold."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:334
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:353
 msgid "Fix: Commercial Lease price display."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:335
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:354
 msgid "Tweak: Output Ensuite to features list."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:339
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:358
 msgid "Version 3.1.2"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:342
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:361
 msgid "Fix: Corrected the address display of the Commercial and Business listing types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:343
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:362
 msgid "Fix: Extension updater class to provide automatic updates."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:344
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:363
 msgid "Tweak: Visiting the plugins page now caches plugin updates."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:348
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:367
 msgid "Version 3.1.1"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:351
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:370
 msgid "Fix: [listing] shortcode with author option correctly filters by username."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:352
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:371
 msgid "Fix: Listing search undefined result when using custom search options."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:356
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:375
 msgid "Version 3.1"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:359
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:378
 msgid "New: Rebuilt templates including additional wrapper for better grid layout."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:360
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:379
 msgid ""
 "New: Added legacy CSS option to prevent using new stylesheets when updating to 3.1 "
 "ensuring your listing display remains consistent."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:361
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:380
 msgid ""
 "New: Enhanced grid wrapper CSS to better display listings in a grid format and "
 "improved CSS by splitting global style.css with style-structure.css allowing for "
 "better compatibility with themes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:362
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:381
 msgid "New: Class based front JS scripts for enhanced compatibility."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:363
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:382
 msgid ""
 "New: Implemented cron checking in extension license handler and updated license "
 "updater EDD code."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:364
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:383
 msgid ""
 "New: Added filter for epl_get_contacts_args to enable contact form field changes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:365
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:384
 msgid "New: Added epl_get_next_contact_link_query filter to adjust contact query."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:366
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:385
 msgid ""
 "New: Added epl_contact_access filter to adjust contact system access by user level."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:367
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:386
 msgid "New: Contextual help tab on listing pages."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:368
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:387
 msgid "New: Added epl_author_description_html filter to adjust the author description."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:369
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:388
 msgid "New: Cron added to handle scheduled events like license checking and updating."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:370
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:389
 msgid "New: Auction epl_auction_feed_format date format filter added."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:371
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:390
 msgid "New: Added epl_get_property_com_rent to allow commercial rent price formatting."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:372
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:391
 msgid "New: Search radio option and checkbox added."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:373
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:392
 msgid "New: Refactored search into class based code."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:374
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:393
 msgid "New: Commercial search added (beta) disabled by default."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:375
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:394
 msgid "New: Conditional post types added for checking on enabled  listing types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:376
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:395
 msgid "New: Support for DIVI theme framework."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:377
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:396
 msgid "New: Added epl_meta_commercial_category_value to adjust commercial category."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:378
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:397
 msgid "New: Parse EPL shortcodes for meta queries."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:379
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:398
 msgid "New: Widget template no image added."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:380
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:399
 msgid "New: Sorting order function added."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:381
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:400
 msgid ""
 "New: Pagination option added to all listing shortcodes pagination = 'on' default."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:382
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:401
 msgid ""
 "New: [listing_category] shortcode added compare option. category_compare = 'IN' usage "
 "is based on SQL query options. 'IN','NOT IN','BETWEEN','NOT BETWEEN'"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:383
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:402
 msgid ""
 "New: Wrapper added to templates to improve display and  provide even grid spacing."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:384
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:403
 msgid "New: Added search address to separate from ID search."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:385
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:404
 msgid "New: No image icon for listing attachments."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:386
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:405
 msgid "New: Display lease price if nothing selected."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:387
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:406
 msgid ""
 "New: Added epl_get_property_price_lease_display filter to control lease price display."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:388
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:407
 msgid ""
 "New: License checker for updates set to daily and constant added to improve plugin "
 "page performance and reduce the update checker frequency."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:389
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:408
 msgid "New: Load custom stylesheet from active_theme/easypropertylistings/style.css"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:390
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:409
 msgid "New: Added Pet Friendly options."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:391
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:410
 msgid "New: Search frontend radio option epl_frontend_search_field_radio."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:392
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:411
 msgid ""
 "New: Search frontend multiple checkbox option "
 "epl_frontend_search_field_checkbox_multiple."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:393
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:412
 msgid "New: Search placeholders added to text fields."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:394
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:413
 msgid "New: Correctly wrap epl_the_excerpt."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:395
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:414
 msgid "New: Divi theme support."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:396
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:415
 msgid "New: Select multiple added as custom field ability."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:397
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:416
 msgid "New: Custom field option checkbox_option."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:398
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:417
 msgid "New: Pet Friendly option added to rentals."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:399
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:418
 msgid "New: Open Parking spaces added to listings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:400
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:419
 msgid "New: Prefixed additional css in templates for better styling."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:401
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:420
 msgid "Tweak: License handler using https."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:402
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:421
 msgid "Tweak: Improvements to contact actions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:403
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:422
 msgid "Tweak: License styling improved for better WordPRess UX."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:404
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:423
 msgid "Tweak: LinkedIn link adjusted for worldwide usage."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:405
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:424
 msgid "Tweak: get_property_meta improved."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:406
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:425
 msgid "Tweak: Commercial leased sticker corrected."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:407
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:426
 msgid "Tweak: property_land_area adjustment for numerical value."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:408
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:427
 msgid "Tweak: Commercial and land category correctly displaying."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:409
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:428
 msgid "Tweak: On activation the Property post type is enabled by default."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:410
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:429
 msgid "Tweak: Improvements to listing widget."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:411
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:430
 msgid "Tweak: Inspection time and date format improved."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:412
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:431
 msgid "Tweak: File option added to external links for floorplans."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:413
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:432
 msgid ""
 "Tweak: Template wrappers prefixed for details, property meta, icons, address, content."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:414
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:433
 msgid "Tweak: Languages moved for better compatibility with translation plugins."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:415
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:434
 msgid "Tweak: Listing search widget status label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:416
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:435
 msgid ""
 "Tweak: Reset page sorting when performing a search on a sub page with a widget or "
 "shortcode."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:417
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:436
 msgid "Tweak: Adjusted price and rental search ranges."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:418
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:437
 msgid "Tweak: Translation fix for rent period."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:419
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:438
 msgid "Tweak: Numerous changes to CSS to improve listing display and responsiveness."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:420
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:439
 msgid "Tweak: Settings checkbox options display correctly."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:421
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:440
 msgid "Tweak: Improvements to author box functions for multi-author."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:422
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:441
 msgid "Tweak: LinkedIn author link adjusted."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:423
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:442
 msgid "Fix: Conditional tags when lo listing types are activated."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:424
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:443
 msgid "Fix: Improved onclick links in external, web links to conform with new JS class."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:425
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:444
 msgid "Fix: Commercial car spaces displaying incorrectly."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:426
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:445
 msgid "Fix: Conditional tags improved."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:429
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:448
 msgid "Version 3.0.4"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:431
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:450
 msgid "Fix: Internal help videos gzip error, using iframe instead."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:432
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:451
 msgid "Fix: Corrected incorrect stray tags on internal welcome page."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:435
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:454
 msgid "Version 3.0.3"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:437
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:456
 msgid ""
 "New: Setting to disable Google Maps API if already added by theme or other plugin."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:438
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:457
 msgid "New: Ability to set a Google Maps API Key."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:439
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:458
 msgid "Fix: Renamed misspelled Property on linked contact."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:440
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:459
 msgid "Fix: Trailing ul tag on search widget."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:441
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:460
 msgid ""
 "Fix: Implemented better timezone support for open for inspection. Requires WordPress "
 "3.9."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:442
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:461
 msgid "Tweak: Tighter spacing on dropdown contact list."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:443
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:462
 msgid "Tweak: Updated translations file."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:444
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:463
 msgid "Tweak: Capital c for contact post type."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:445
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:464
 msgid "Tweak: Dashboard activity widget improved CSS display."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:446
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:465
 msgid "Tweak: Dashboard activity comments better labeled."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:447
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:466
 msgid "Tweak: Internal links to documentation corrected."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:450
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:469
 msgid "Version 3.0.2"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:452
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:471
 msgid "Fix: Featured Listing removed redundant no option."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:455
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:474
 msgid "Version 3.0.1"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:457
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:476
 msgid "Tweak: Versioning to all CSS and JS."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:458
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:477
 msgid "New: Arabic translation."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:459
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:478
 msgid "Tweak: Updated German Translation."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:460
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:479
 msgid "Tweak: Updated French Translation."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:461
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:480
 msgid "Tweak: Updated Dutch Translation."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:462
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:481
 msgid ""
 "Fix: Search by Address and Property ID correctly searches the listing Title. In order "
 "to search by property ID, add the property ID to the listing title."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:463
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:482
 msgid "New: Customise the EPL - Contact Form Widget Submit Label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:464
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:483
 msgid "Tweak: Added Form styling to contact form."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:465
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:484
 msgid "Tweak: Corrected additional translation strings with contact form labels."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:466
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:485
 msgid "Tweak: Corrected spacing in extension plugin updates."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:467
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:486
 msgid "Tweak: Renamed EPL - Contact Form Subscribe label to Submit."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:470
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:489
 msgid "Version 3.0"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:472
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:491
 msgid ""
 "Tweak: Textdomain and languages files renamed. Changed from epl to easy-property-"
 "listings for the WordPress.org translation initiative."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:473
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:492
 msgid ""
 "New: Every epl_action present in the $_GET or $_POST is called using WordPress "
 "do_action function in init."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:474
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:493
 msgid ""
 "Tweak: Radio options when adding listings converted to checkboxes to slim down the "
 "admin pages."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:475
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:494
 msgid "Fix: Ducted Heating additional features now displays in feature list."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:476
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:495
 msgid "Fix: Fully fenced option now displays in feature list."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:477
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:496
 msgid "Tweak: Optimise Admin Listing queries."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:478
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:497
 msgid "Tweak: Removed double display of Under Offer in admin listing list."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:479
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:498
 msgid "Tweak: Leased rental listings now display the weekly rent amount in admin."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:480
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:499
 msgid "Tweak: Commercial Lease listing details improved in admin list."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:481
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:500
 msgid "Tweak: Sold price displays in admin."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:482
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:501
 msgid "Fix: Date Available fix for year."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:483
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:502
 msgid "New: epl_get_property_available filter allows customising date format."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:484
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:503
 msgid "Tweak: External links function improved."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:485
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:504
 msgid ""
 "Tweak: Added additional plugin file security access to prevent file reading outside "
 "of WordPress."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:486
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:505
 msgid "Fix: Number Formatting function PHP warning fixed."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:487
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:506
 msgid "Fix: is_epl_post function to prevent error when no posts are activated."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:488
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:508
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:507
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:527
 msgid "Tweak: Commercial auction listing support."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:489
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:508
 msgid "New: Contacts and form system for managing listing leads and history of contact."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:490
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:509
 msgid "New: contact_capture shortcode // Needs Author id of page and URL."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:491
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:510
 msgid "New: Contact System for Lead Generation and Capture."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:492
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:511
 msgid "New: Form API supports editor."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:493
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:512
 msgid "New: Dashboard Widget Listing and Contact Activity Feed."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:494
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:513
 msgid ""
 "New: Date Picker updated JS for improved usage and improved compatibility with themes "
 "and plugins."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:495
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:514
 msgid ""
 "Tweak: Code Docblocks created for http://docs.easypropertylistings.com.au code "
 "reference."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:496
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:515
 msgid ""
 "New: Link a contact with a listing and display details and quick access to contact."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:497
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:516
 msgid "New: Error tracking and debug logging helper functions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:498
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:517
 msgid "New: Form API supports sections breaks."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:499
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:518
 msgid "New: Contextual help tab added to Add/Edit Listing page."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:500
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:519
 msgid "New: Inspection date format now customisable from settings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:501
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:520
 msgid "Tweak: Extension license updater updated."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:502
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:521
 msgid ""
 "Tweak Added additional map CSS classes to improve Google Map output with some themes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:503
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:522
 msgid ""
 "New: Adjustable Map pin when editing a listing and setting coordinates. Drag the map "
 "pin to adust the position."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:504
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:523
 msgid "Tweak: Imported values of 0 no longer display on commercial listings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:505
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:524
 msgid ""
 "Tweak: epl_render_html_fields allows for css class set in the field array of meta-"
 "boxes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:506
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:525
 msgid "Tweak: Commercial authority default type is now For Sale instead of Auction."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:507
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:526
 msgid "Tweak: Converted Radio options to tick boxes to reduce space."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:509
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:528
 msgid "Tweak: Bedrooms allow studio option."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:510
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:529
 msgid "Tweak: Applied thousands separator to land sizes using settings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:511
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:530
 msgid "Tweak: Allow for .00 and .0 when adding listing prices."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:512
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:531
 msgid "Tweak: Toilet supports decimal."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:513
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:532
 msgid ""
 "Tweak: Additional Features increased to three columns to minimise space with single "
 "checkboxes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:514
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:533
 msgid ""
 "Tweak: Listing price, sale, and rental price now supports decimal values when saving."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:515
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:534
 msgid "Tweak: Bond supports decimal figures."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:516
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:535
 msgid "Tweak: Translation strings fixed."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:517
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:536
 msgid "Tweak: m2 html character added."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:518
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:537
 msgid "Tweak: Listings with prices set to 0 like bond no longer display in admin."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:519
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:538
 msgid ""
 "Fix: Rental listing when using price text the rental period no longer displays in "
 "admin."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:520
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:539
 msgid "Tweak: Pagination loading globally for use in admin."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:521
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:540
 msgid "New: Pagination enhanced to enable adjustment of output."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:522
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:541
 msgid ""
 "Fix: Old function in metaboxes removed as it inadvertently caused additional "
 "unnecessary queries."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:523
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:542
 msgid ""
 "New: Generate visual reports on your listing KPI status so you can track your "
 "listings and sales."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:524
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:543
 msgid ""
 "Tweak: [listing_search] shortcode using new API and allows for custom templates. "
 "Place the template in themes/your_theme/easypropertylistings/templates/ folder."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:525
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:544
 msgid "Tweak: Enhanced Search Object thanks to codewp allows widget template override."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:526
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:545
 msgid "Tweak: Building value now accepts decimal."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:527
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:546
 msgid ""
 "New: Search Widget and [listing_search] shortcode allows for property status option."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:528
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:547
 msgid "New: Search template now editable using epl_get_template_part."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:529
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:548
 msgid ""
 "New: Search widget and [listing_search] shortcode order option added to allow "
 "adjusting of field order."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:530
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:549
 msgid "New: Second agent field allows for searching users."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:531
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:550
 msgid "New: Search upgraded to object thanks to codewp."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:532
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:551
 msgid "New: Search for second listing author on listings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:533
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:552
 msgid "New: Search widget and [listing_search] shortcode status search option added."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:534
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:553
 msgid ""
 "New: Search widget and [listing_search] shortcode support any registered post types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:535
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:554
 msgid ""
 "New: Search widget and [listing_search] shortcode support single drop down selection "
 "for price, land, building."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:536
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:555
 msgid ""
 "Fix: Session start less likely to cause issues with certain server configurations."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:537
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:556
 msgid "Fix: listing_open shortcode no longer displays sold or leased listings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:538
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:557
 msgid "New: Additional customisation of shortcode-listing.php template part."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:539
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:558
 msgid "Tweak: Listing Shortcode adjusted for better processing of options."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:540
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:559
 msgid "New: [listing_auction] shortcode."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:541
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:560
 msgid "New: Contact shortcode. [epl_contact_form]."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:542
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:561
 msgid "New: Contact Form Widget."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:543
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:562
 msgid "New: Sort by location A-Z added to front end listing filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:544
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:563
 msgid ""
 "Tweak: iThemes Builder archive-listing.php and single-listing.php templates updated "
 "to improve render_content theme function."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:545
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:564
 msgid "New: Allow extensions to use core templates for output."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:546
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:565
 msgid "Fix: Added translation string for P.A. label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:547
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:566
 msgid "Fix: Translation of land size unit."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:548
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:567
 msgid "Tweak: LinkedIn will use full URL or fallback."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:549
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:568
 msgid "New: Default embedded video width adjustable from settings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:550
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:569
 msgid ""
 "New: Video links now support additional formats like Vimeo using the WordPress "
 "wp_oembed."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:551
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:570
 msgid "New: Listing widget now loadable using epl_get_template_part thanks to codewp."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:552
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:571
 msgid "Tweak: Widget descriptions added to widget management."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:553
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:572
 msgid "Fix: Stray ul tag with search widget tabbing."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:554
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:573
 msgid ""
 "Tweak: Improved get_additional_features_html function for additional features and "
 "added epl_get_additional_features_html filter"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:555
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:574
 msgid "New: Contact tags taxonomy added for creating your own contact tags."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:556
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:575
 msgid "Tweak: Listing heading function enhanced for other post types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:557
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:576
 msgid ""
 "New: epl_get_property_feature_taxonomy filter allowing adjustment of listing features."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:558
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:577
 msgid "New: epl_get_property_auction filter allows adjustment of auction date format."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:559
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:578
 msgid "New: epl_get_property_auction_label filter to adjust the Auction label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:560
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:579
 msgid "New: Support for Twenty Sixteen theme."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:561
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:580
 msgid "Tweak: Active theme function enhanced for older WordPress versions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:562
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:581
 msgid "New: Templates added for Twenty Fourteen Theme to improve display."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:563
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:582
 msgid ""
 "New: Archive title action added for easier implementation and filters to adjust "
 "output."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:564
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:583
 msgid ""
 "New: epl_feedsync_format_strip_currency function to strip currency during import with "
 "epl_feedsync_format_strip_currency_symbol filter to modify string replacement search."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:565
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:584
 msgid "New: epl_archive_title_search_result Filter, default \"Search Result\"."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:566
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:585
 msgid "New: epl_archive_title_fallback Filter, default \"Listing\"."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:567
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:586
 msgid "New: epl_archive_title_default Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:568
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:587
 msgid "New: epl_get_active_theme Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:569
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:588
 msgid "New: epl_active_theme Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:570
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:589
 msgid "New: epl_active_theme_name Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:571
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:590
 msgid "New: epl_active_theme_prefix Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:572
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:591
 msgid "New: epl_archive_title_fallback Filer."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:573
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:592
 msgid "Tweak: epl_strip_tags function added filter to adjust HTML tag stripping."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:574
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:593
 msgid "New: epl_contact_form_description_allowed_tags Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:575
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:594
 msgid "New: epl_get_property_price_display Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:576
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:595
 msgid "New: epl_get_property_price_sold_display Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:577
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:596
 msgid "New: epl_get_property_price_sold_date Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:578
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:597
 msgid "New: epl_get_property_rent Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:579
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:598
 msgid "New: epl_get_property_bond Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:580
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:599
 msgid "New: epl_get_property_land_category Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:581
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:600
 msgid "New: epl_commercial_auction_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:582
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:601
 msgid "New: epl_get_property_auction_date Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:583
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:602
 msgid "New: epl_get_price_plain_value Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:584
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:603
 msgid "New: epl_get_price Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:585
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:604
 msgid "New: epl_get_price_sticker Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:586
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:605
 msgid "New: epl_get_price_in_list Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:587
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:606
 msgid "New: epl_get_property_commercial_category Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:588
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:607
 msgid "New: epl_get_property_year_built_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:589
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:608
 msgid "New: epl_get_property_year_built Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:590
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:609
 msgid "New: epl_get_property_bath_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:591
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:610
 msgid "New: epl_get_property_bathrooms_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:592
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:611
 msgid "New: epl_get_property_bath Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:593
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:612
 msgid "New: epl_get_property_bed_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:594
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:613
 msgid "New: epl_get_property_bedrooms_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:595
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:614
 msgid "New: epl_get_property_bed Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:596
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:615
 msgid "New: epl_get_property_rooms_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:597
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:616
 msgid "New: epl_get_property_rooms Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:598
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:617
 msgid "New: epl_get_parking_spaces_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:599
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:618
 msgid "New: epl_get_property_parking Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:600
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:619
 msgid "New: epl_get_property_garage_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:601
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:620
 msgid "New: epl_get_property_garage Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:602
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:621
 msgid "New: epl_get_property_carport_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:603
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:622
 msgid "New: epl_get_property_carport Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:604
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:623
 msgid "New: epl_get_property_air_conditioning_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:605
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:624
 msgid "New: epl_get_property_air_conditioning Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:606
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:625
 msgid "New: epl_get_property_pool_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:607
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:626
 msgid "New: epl_get_property_pool Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:608
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:627
 msgid "New: epl_get_property_security_system_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:609
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:628
 msgid "New: epl_get_property_security_system Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:610
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:629
 msgid "New: epl_get_property_land_area_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:611
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:630
 msgid "New: epl_get_property_land_value Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:612
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:631
 msgid "New: epl_get_property_building_area_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:613
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:632
 msgid "New: epl_get_property_building_area_value Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:614
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:633
 msgid "New: epl_get_property_new_construction_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:615
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:634
 msgid "New: epl_get_property_new_construction Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:616
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:635
 msgid "New: epl_get_property_com_car_spaces_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:617
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:636
 msgid "New: Dynamic additional features epl_get_{meta_key}_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:618
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:637
 msgid "New: epl_get_additional_features_html Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:619
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:638
 msgid "New: epl_get_additional_rural_features_html Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:620
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:639
 msgid "New: epl_get_additional_commerical_features_html Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:621
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:640
 msgid "New: epl_get_features_from_taxonomy Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:622
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:641
 msgid "New: epl_checkbox_single_check_options Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:623
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:642
 msgid "New: epl_property_sub_title_plus_outgoings_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:624
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:643
 msgid "New: epl_property_sub_title_available_from_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:625
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:644
 msgid "New: epl_property_sub_title_available_now_label Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:626
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:645
 msgid "New: epl_get_formatted_property_address filter Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:627
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:646
 msgid "New: epl_get_property_category  Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:628
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:647
 msgid "New: epl_get_property_tax Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:629
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:648
 msgid ""
 "New: epl_property_sub_title_property_features filter for Property Features label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:630
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:649
 msgid "New: epl_property_sub_title_plus_outgoings filter for Plus Outgoings label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:631
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:650
 msgid ""
 "New: epl_property_sub_title_commercial_features filter for Commercial Features label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:632
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:651
 msgid "New: epl_property_sub_title_rural_features filter for Rural Features label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:633
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:652
 msgid "New: epl_switch_views_sorting_title_sort filter for Sort label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:634
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:653
 msgid "New: epl_switch_views_sorting_title_list filter for List label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:635
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:654
 msgid "New: epl_switch_views_sorting_title_grid filter for Grid label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:636
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:655
 msgid "New: epl_pagination_before_page_numbers  Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:637
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:656
 msgid "New: epl_pagination_after_page_numbers  Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:638
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:657
 msgid "New: epl_pagination_single_content_text Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:639
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:658
 msgid "New: epl_pagination_single_tag  Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:640
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:659
 msgid "New: epl_pagination_single Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:641
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:660
 msgid "New: epl_pagination_single_dot_tag Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:642
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:661
 msgid "New: epl_pagination_single_dot_content Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:643
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:662
 msgid "New: epl_pagination_single_dot_attributes Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:644
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:663
 msgid "New: epl_pagination_single_dot Filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:647
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:666
 msgid "Version 2.3.1"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:649
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:668
 msgid ""
 "New: Added a hidden field property_images_mod_date for image mod time in preparation "
 "for importer plugin."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:650
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:669
 msgid ""
 "Tweak: Added categories to search for business, rural, land, commercial, "
 "commercial_land post types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:651
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:670
 msgid "Tweak: Adjusted z-index of sticker label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:652
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:671
 msgid "Tweak: Hide address separator when address is empty."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:653
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:672
 msgid "Fix: Search price fix for commercial, commercial_land, and business."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:654
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:673
 msgid "Fix: POA label now obeys custom label setting."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:657
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:676
 msgid "Version 2.3"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:659
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:678
 msgid ""
 "New: Custom Post Type API. Makes it easy to create and register new custom post types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:660
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:679
 msgid ""
 "New: Custom Meta Box API. Creating custom fields and being able to configure custom "
 "meta fields on existing and new post types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:661
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:680
 msgid ""
 "New: Custom Forms API. Will give the ability to create forms and submissions for the "
 "coming CRM. (Customer Relationship Manager)."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:662
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:681
 msgid "New: Ordering of extension dynamic custom fields now possible."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:663
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:682
 msgid ""
 "New: Archive template attributes class dynamically added depending on template in use."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:664
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:683
 msgid ""
 "New: A number of helper functions have been added to better integrate additional "
 "custom post types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:665
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:684
 msgid "New: Button meta field for use in extensions and custom fields."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:666
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:685
 msgid "New: Adjustments to video output function."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:667
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:686
 msgid "New: Features taxonomy now use archive template instead of blog post view."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:668
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:687
 msgid ""
 "New: Filters to adjust the Search not found text epl_property_search_not_found_title "
 "and epl_property_search_not_found_message."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:669
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:688
 msgid ""
 "Tweak: Restored get_property_suburb function which was used in Listing Templates."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:670
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:689
 msgid "Tweak: Better author linking and real estate agent user output."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:671
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:690
 msgid "Tweak: Improvements for other extensions to hook into and use maps."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:672
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:691
 msgid "Tweak: Template fallback functions for improved custom template usage."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:673
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:692
 msgid "Tweak: Swedish translations updated."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:674
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:693
 msgid "Tweak: Translation file updated."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:675
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:694
 msgid "Fix: New Construction class corrected to new_construction instead of pool."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:676
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:695
 msgid ""
 "Fix: Property ID searching improved. If you have a-z characters in your id include "
 "them in the title. E.g. aaa222 - 9 Somewhere Street, Brooklyn NY."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:679
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:698
 msgid "Version 2.2.7"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:681
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:700
 msgid "Tweak: Compatibility for Listing Templates extension."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:684
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:703
 msgid "Version 2.2.6"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:686
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:705
 msgid ""
 "Fix: Updated extension licensing updater to use https. Update required in order to be "
 "able to auto-update your extensions as Easy Property Listings has moved to https."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:689
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:708
 msgid "Version 2.2.5"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:691
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:710
 msgid "Fix: Widget construct fixes for WordPress 4.3."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:692
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:711
 msgid "Tweak: Un-install function."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:693
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:712
 msgid "Tweak: Plugin page link to settings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:694
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:713
 msgid "Tweak: Languages updated."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:697
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:716
 msgid "Version 2.2.4"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:699
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:718
 msgid ""
 "Tweak: Improvements to Commercial/Commercial Land/Business pricing when set to Lease "
 "type to display free form price text."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:700
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:719
 msgid "Tweak: Bar graph in dashboard will no longer cover address if set to low."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:701
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:720
 msgid "Tweak: Added sticker CSS styling for single listing."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:702
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:721
 msgid "Fix: Search Widget/Shortcode display house category value instead of key."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:703
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:722
 msgid "Fix: Search Widget/Shortcode Property ID correctly searches numeric listing ID."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:704
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:723
 msgid ""
 "Fix: Search Widget/Shortcode excluded non searchable fields from land, commercial, "
 "commercial land and business post types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:707
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:726
 msgid "Version 2.2.3"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:709
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:728
 msgid "Tweak: Adjusted new sorter function to work on lower than PHP version 5.3."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:710
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:729
 msgid ""
 "Tweak: Moved old template functions to theme compatibility, will be removed in future "
 "version."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:711
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:730
 msgid ""
 "Tweak: Set sorter list style to none to prevent some themes from displaying a list "
 "bullet."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:714
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:733
 msgid "Version 2.2.2"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:716
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:735
 msgid "Tweak: CSS tweak for image size to retain proportion on some themes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:717
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:736
 msgid ""
 "Tweak: Adjusted position of show/hide suburb on Commercial/Business listing types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:718
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:737
 msgid "Fix: Archive image correctly loading 300x200 image."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:719
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:738
 msgid "Fix: Listing address display settings fixed."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:722
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:741
 msgid "Version 2.2.1"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:724
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:743
 msgid "Tweak: Set padding for search tabs for better display on some themes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:725
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:744
 msgid "Fix: Search function fix checking for empty option when using custom filters."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:728
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:747
 msgid "Version 2.2"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:730
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:749
 msgid ""
 "New: Search shortcode and widget rebuilt to enable adding additional fields through "
 "filters and hooks."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:731
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:750
 msgid ""
 "New: Search shortcode and widget added additional search fields for City, State, "
 "Postcode and Country."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:732
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:751
 msgid ""
 "New: Search shortcode and widget allows for optional multi select of house category."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:733
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:752
 msgid "New: Search shortcode and widget improved responsive CSS."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:734
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:753
 msgid "New: Grid styles included in main CSS for use in extensions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:735
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:754
 msgid ""
 "New: Upload button added for use in custom plug-ins and extensions to upload files."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:736
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:755
 msgid "New: Filter to adjust tour labels."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:737
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:756
 msgid "New: Filters to adjust Floor Plan labels."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:738
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:757
 msgid "New: Filters to adjust External Link labels."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:739
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:758
 msgid "New: Sold prices now display when set on front end and manage listings pages."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:740
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:759
 msgid "New: Label function for returning meta labels."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:741
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:760
 msgid ""
 "New: Ads on settings no longer display when there is an activated extension present."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:742
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:761
 msgid "New: Locked and help cases options for use in extensions and custom plugins."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:743
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:762
 msgid ""
 "New: Theme compatibility mode which enables all themes to display correctly with "
 "options to disable featured images for themes that automatically add featured images."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:744
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:763
 msgid ""
 "New: City setting to allow addresses in countries that need more than a suburb Label "
 "is customisable from settings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:745
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:764
 msgid "New: Country setting to allow the country to display with the listing address."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:746
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:765
 msgid "New: Able to adjust or add more registered thumbnail sizes through a filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:747
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:766
 msgid "New: Function to get all the values associated with a specific post meta key."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:748
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:767
 msgid ""
 "New: Replaced the_post_thumbnail on archive pages and shortcodes with a customisable "
 "hook allowing for additional customisation with themes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:749
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:768
 msgid ""
 "New: Specific templates for theme compatibility mode for archive and single listings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:750
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:769
 msgid ""
 "New: Template loading system allowing for additional templates to be added to "
 "shortcodes and widgets from themes, custom plug-ins and extensions. This allows you "
 "to create an unlimited number of templates and load them from your theme."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:751
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:770
 msgid "New: Sorter allows for sorting by current/sold leased."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:752
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:771
 msgid "New: Ability to add additional sorter via filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:753
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:772
 msgid "New: Post counter function for use in extensions and custom plug-ins."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:754
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:773
 msgid "New: User fields re-built which allows for adding on new fields through filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:755
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:774
 msgid "New: Help meta type allowing for better internal documentation in extensions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:756
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:775
 msgid "New: City meta field added to all listing types when enabled."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:757
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:776
 msgid "New: Rental display or hide rental price."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:758
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:777
 msgid "New: Check-box single field type."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:759
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:778
 msgid ""
 "New: Actions added to enable extensions to better hook into listings types and "
 "optimised functions for admin column details."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:760
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:779
 msgid "New: Dashboard widget now displays other extensions content counts."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:761
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:780
 msgid ""
 "New: Listing widget now allows for additional selectable templates to be added "
 "through custom plug-ins, hooks and themes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:762
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:781
 msgid "New: Replaced widget image with a dynamic action."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:763
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:782
 msgid "New: Filter added for Gravatar image."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:764
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:783
 msgid "New: Replaced widget and author box image functions with actions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:765
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:784
 msgid "New: Uninstall function to remove all Easy Property Listings content."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:766
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:785
 msgid "New: Get option function."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:767
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:786
 msgid ""
 "New: When saving settings on extensions sub tabs you are no longer taken to the first "
 "tab."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:768
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:787
 msgid "New: Customisable state label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:769
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:788
 msgid "Tweak: Improved under offer, sold and leased labels."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:770
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:789
 msgid ""
 "Tweak: Improved install function to reduce code and allow for new settings to be "
 "added."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:771
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:790
 msgid "Tweak: Removed redundant code and streamlined templates."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:772
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:791
 msgid "Tweak: Improved reset query function."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:773
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:792
 msgid "Tweak: Removed old functions improving plugin code."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:774
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:793
 msgid "Tweak: Rebuilt address function to allow for city and country."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:775
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:794
 msgid "Tweak: Improved sorter function in all shortcodes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:776
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:795
 msgid ""
 "Tweak: Improvements to Commercial and Business listing types to better comply with "
 "REAXML format with business takings, franchise, terms and commercial outgoings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:777
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:796
 msgid "Tweak: Reorganised settings page."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:778
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:797
 msgid "Tweak: Translations updated and additional tags added."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:779
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:798
 msgid ""
 "Tweak: Search button default label changed from \"Find Me A Property!\" to \"Search\"."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:780
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:799
 msgid "Tweak: Applied custom suburb label to EPL - Listing Widget."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:781
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:800
 msgid "Fix: Listings house categories correctly display labels instead of values."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:782
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:801
 msgid "Fix: Listings with carport, garage or values set to zero no longer display."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:783
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:802
 msgid "Fix: Shortcode compatibility for WordPress 3.3 thanks to codewp"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:784
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:803
 msgid "Fix: Saving listing when in debug mode and ticking hide map or hide author box."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:785
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:804
 msgid "Fix: New Zealand currency now displays a dollar sign."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:788
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:807
 msgid "Version 2.1.11"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:791
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:810
 msgid ""
 "Tweak: Removed sub titles \"Property Manager\" and \"Real Estate Agent\" from the "
 "single listing template for better language support and to facilitate the hiding of "
 "the author box."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:792
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:811
 msgid "Tweak: Added epl- prefix to all author-box and widget css."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:793
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:812
 msgid ""
 "Tweak: Renamed author-box container with epl-author-box-container as it was harder to "
 "target the author box content and adjusted JS for tabs."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:794
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:813
 msgid "Tweak: Improved author box responsive CSS."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:795
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:814
 msgid "Tweak: Updated extension updater for multisite and other improvements."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:796
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:815
 msgid "Tweak: Leased label when adding a property will use custom label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:797
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:816
 msgid "Tweak: Wrapper class for property category."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:798
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:817
 msgid "Fix: Undefined status if importing listings not using current status."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:799
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:818
 msgid ""
 "Fix: When user selects grid/list option and pages the user selected view is retained."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:800
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:819
 msgid "Fix: [listing post_type=\"rental\"] shortcode price sorting for rental."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:801
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:820
 msgid "New: Author box is now able to be hidden on a per listing basis."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:802
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:821
 msgid "New: Added filters for author box social links."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:803
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:822
 msgid "New: Inspection filter to adjust the inspection date/time format."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:804
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:823
 msgid ""
 "New: Several author widget filters added to enable additional content through "
 "extensions or custom functions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:805
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:824
 msgid ""
 "New: Sold, leased, under offer label filter which uses the label setting and label "
 "changes dashboard widget, admin category filters and search widget."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:806
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:825
 msgid "New: Sold label making Sold STC possible or other Sold label variant."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:807
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:826
 msgid "New: Danish language thanks to pascal."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:808
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:827
 msgid "New: German language thanks to ChriKn."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:809
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:828
 msgid "New: Ukrainian language thanks to Alex."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:810
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:829
 msgid "New: Swedish language thanks to Roland J."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:813
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:832
 msgid "Version 2.1.10"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:816
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:835
 msgid "New: Email field validation added."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:817
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:836
 msgid "New: Added status classes to widgets for better targeting of CSS styles."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:818
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:837
 msgid "Tweak: Improved video embed and added a filter to adjust video container size."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:819
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:838
 msgid ""
 "Tweak: Improved CSS wrappers for listing widget and added dynamic class depending on "
 "widget display style."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:820
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:839
 msgid "Tweak: Added additional classes to Listing Widget list variant style list items."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:821
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:840
 msgid "Fix: Additional paging issues fixed in listing widget for other options."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:822
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:841
 msgid "Fix: Widget leased selection displays rentals correctly."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:825
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:844
 msgid "Version 2.1.9"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:828
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:847
 msgid "Fix: Fixed paging issues in listing widget."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:829
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:848
 msgid "Fix: Fix shortcodes when using multiple listing post types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:832
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:851
 msgid "Version 2.1.8"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:835
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:854
 msgid "New: Ability to disable all plugin CSS from Advanced Settings section."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:836
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:855
 msgid "New: Search widget and shortcode now have the option to turn of Location search."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:837
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:856
 msgid ""
 "New: Search widget and shortcode now have filters to control the display of \"Any\". "
 "Each field has a unique filter which will allow you to hide the label using CSS and "
@@ -3612,15 +3679,15 @@ msgid ""
 "create super slim search boxes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:838
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:857
 msgid "New: Added translation Belgian (Dutch) thanks to pascal.beyens"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:839
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:858
 msgid "New: Polish translation thanks to Weronika.urbanczyk"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:840
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:859
 msgid ""
 "New: Two mew shortcode templates table and table_open usable with shortcodes to "
 "provide a slim list of listings. Example usage is [listing_open template=\"table\"] "
@@ -3628,310 +3695,310 @@ msgid ""
 "theme/easypropertylistings folder to further customize."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:841
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:860
 msgid ""
 "New: Added currency support for Qatar Riyal (QAR), United Arab Emirates (AED), "
 "Ukrainian Hryvnia (UAH), Vietnamese đồng (VND)"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:842
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:861
 msgid "New: checkbox_single ability for plugin and extensions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:843
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:862
 msgid "New: Ability to disable map on each listing."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:844
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:863
 msgid ""
 "Tweak: Updated currency symbols for: Israeli Shekel, Thai Baht, Indian Rupee, Turkish "
 "Lira, Iranian Rial."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:845
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:864
 msgid ""
 "Tweak: Improved CSS and added additional classes with epl- prefix in templates and "
 "search."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:846
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:865
 msgid "Tweak: Improved CSS for Location Profiles and Staff Directory extensions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:847
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:866
 msgid ""
 "Tweak: Added filters for commercial titles to allow you to change \"For Lease\" and "
 "\"For Sale\" using epl_commercial_for_lease_label, and epl_commercial_for_sale_label "
 "filters."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:848
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:867
 msgid "Tweak: Additional CSS classes for Land, Commercial and Rural special features."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:849
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:868
 msgid "Tweak: Gallery CSS classes added."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:850
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:869
 msgid ""
 "Tweak: Improved table shortcodes CSS and styling for better full display and "
 "responsive widths."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:851
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:870
 msgid "Fix: New/Open Sticker now appear on listings with the price display set to no."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:852
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:871
 msgid "Fix: Translations work correctly for categories."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:855
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:874
 msgid "Version 2.1.7"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:858
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:877
 msgid ""
 "New: listing_search shortcode now has style option for adjusting the width. You can "
 "add style=\"slim\" or style=\"wide\" to the shortcode to adjust the appearance."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:859
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:878
 msgid "New: Listing Search widget now has style options for adjusting the width."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:860
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:879
 msgid "Tweak: Updated translation and added missing sqm translation element."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:861
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:880
 msgid "Tweak: Allowed for hundredths decimal in bathrooms field."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:862
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:881
 msgid "Tweak: Floor plan button CSS."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:863
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:882
 msgid "Tweak: Address and price responsive CSS."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:864
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:883
 msgid "Fix: Auction listing price set to no displays auction date correctly."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:865
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:884
 msgid "Fix: Fix: Author position css class."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:868
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:887
 msgid "Version 2.1.6"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:871
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:890
 msgid "Fix: Fancy pagination paging works correctly when shortcodes used on home page."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:872
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:891
 msgid "Fix: Wrapped new pagination feature in esc_url to prevent vulnerability."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:873
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:892
 msgid ""
 "Fix: Corrected sorting by price when using shortcodes. Note: Rental sorting works on "
 "post_type=\"rental\" in all shortcodes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:874
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:893
 msgid ""
 "Tweak: Added rental rate view for text entry of rental rates for REAXML compatibility."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:875
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:894
 msgid ""
 "Tweak: Corrected admin display columns and edit listing pages for better display on "
 "mobile devices."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:878
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:897
 msgid "Version 2.1.5"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:881
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:900
 msgid ""
 "Tweak: Commercial listing: Ability to set commercial lease rate to a decimal value "
 "using the epl_price_number_format_commercial_lease filter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:882
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:901
 msgid "Tweak: Updated epl.pot translation file."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:883
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:902
 msgid ""
 "Tweak: Removed horizontal line elements in the help section to match WordPress 4.2 "
 "admin page styles."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:884
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:903
 msgid ""
 "Tweak: Rental Listing: Added epl_property_bond_position filter to adjust the position "
 "of the Bond/Deposit to appear either before or after the value."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:885
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:904
 msgid "Tweak: Rental Listing: Removed CSS padding before bond value."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:886
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:905
 msgid ""
 "Fix: Rental Listing: Adjusting the Bond/Deposit label will now show your custom label "
 "in the Rental Price box."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:887
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:906
 msgid "Fix: Rural Listing: Undefined label_leased variable."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:888
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:907
 msgid ""
 "Note: Confirmed Easy Property Listings is not vulnerable to recent WordPress exploit."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:889
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:908
 msgid "New: Added setting to show/hide Listing Unique ID column when managing listings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:892
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:911
 msgid "Version 2.1.4"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:895
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:914
 msgid "Tweak: Pagination optimised and no longer loads in admin."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:896
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:915
 msgid "Tweak: New filter epl_price_number_format added for decimal rental rates."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:897
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:916
 msgid "Fix: Display custom bond label when viewing listings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:898
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:917
 msgid ""
 "Tweak: Added filter epl_floorplan_button_label_filter to adjust Floor Plan button "
 "label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:901
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:920
 msgid "Version 2.1.3"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:904
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:923
 msgid ""
 "Fix: Author box upgraded to allow for custom tabs and better extension integration "
 "with author box and widget."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:905
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:924
 msgid "Fix: Added additional epl-author-archive CSS class for author archive pages."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:906
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:925
 msgid "Fix: Improved CSS classes for author box with better responsive support."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:907
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:926
 msgid "Fix: Added additional filters for author contact information."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:908
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:927
 msgid ""
 "Fix: Added secondary global author function for simpler integration for extensions "
 "like the Staff Directory."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:909
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:928
 msgid "Fix: Changes to author tempaltes and restored author position variable."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:910
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:929
 msgid "Fix: Further improved max and min graph values when in listing admin."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:913
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:932
 msgid "Version 2.1.2"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:915
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:934
 msgid "Fix: Improved Responsive CSS for grid style."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:916
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:935
 msgid ""
 "Fix: Twenty Fifteen, Twenty Fourteen, Twenty Thirteen, Twenty Twelve CSS styles for "
 "better display."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:917
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:936
 msgid "New: Added CSS class theme name output to archive and single templates."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:920
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:939
 msgid "Version 2.1.1"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:922
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:941
 msgid ""
 "Fix: Max price defaults set for graph calculations when upgrading from pre 2.0 "
 "version."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:925
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:944
 msgid "Version 2.1"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:927
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:946
 msgid "New: Fancy pagination option which can be enabled in settings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:928
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:947
 msgid "New: Coordinates now added to listing if not set prior."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:929
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:948
 msgid "New: Ability to select larger listing image sizes in admin."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:930
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:949
 msgid "New: Added date picker for available date on rental listing."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:931
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:950
 msgid "New: Added date picker for sold date."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:932
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:951
 msgid ""
 "New: New function that combines all meta box options into one global function for "
 "admin pages."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:933
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:952
 msgid "New: Display second agent name in admin listing lists."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:934
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:953
 msgid "New: Additional admin option to filter by agent/author. "
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:935
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:954
 msgid "New: Shortcode [listing_location] to display listings by specific location."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:936
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:955
 msgid ""
 "New: The following shortcodes can now be filtered by location taxonomy: [listing "
 "location=\"perth\"], [listing_open location=\"sydney\"], [listing_category location="
@@ -3939,485 +4006,485 @@ msgid ""
 "\"terrace\" location=\"new-york\"]"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:937
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:956
 msgid ""
 "New: The following shortcodes can now be sorted by price, date and ordered by ASC and "
 "DESC [listing sortby=\"price\" sort_order=\"ASC\"]."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:938
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:957
 msgid ""
 "New: Sorter added to shortcodes which can be enabled by adding tools_top=\"on\" to "
 "your shortcode options."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:939
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:958
 msgid "New: Template added in table format for use in shortcodes template=\"table\"."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:940
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:959
 msgid "New: Function to get all active post types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:941
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:960
 msgid "New: Ability to register additional custom post types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:942
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:961
 msgid "New: Extensions now have additional help text ability."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:943
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:962
 msgid "New: All menus now use global function to render fields."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:944
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:963
 msgid ""
 "New: Improved template output and added additional CSS wrappers for some theme and "
 "HTML5 themes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:945
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:964
 msgid "New: Commercial rental lease duration now selectable."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:946
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:965
 msgid "New: Rooms field added to set the number of rooms that the listing has."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:947
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:966
 msgid "New: Date listed field added to all listing types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:948
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:967
 msgid "New: Year built field added to property, rental, rural listing types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:949
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:968
 msgid "New: Media upload function for use in extensions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:950
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:969
 msgid "New: Ability to customise Under Offer and Leased labels in settings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:951
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:970
 msgid ""
 "New: Lease type label loaded from dropdown select. So you can have NNN, P.A., Full "
 "Service, Gross Lease Rates, on commercial listing types. Also has a filter to enable "
 "customisation of the options."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:952
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:971
 msgid "New: Disable links in the feature list."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:953
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:972
 msgid "Fix: Text domain fixes on template files."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:954
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:973
 msgid "Fix: Finnish translation file renamed."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:955
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:974
 msgid "Fix: FeedSync date processor strptime function corrected."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:956
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:975
 msgid ""
 "Fix: Bug in parking search field. Was only searching carports and not garages. Now "
 "searches both."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:957
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:976
 msgid "Fix: New label now appears on listings not just with an inspection time saved."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:958
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:977
 msgid "Tweak: Optimised loading of admin scripts and styles to pages where required."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:959
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:978
 msgid ""
 "Tweak: Added version to CSS and JS so new versions are automatically used when plugin "
 "is updated."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:960
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:979
 msgid "Tweak: Tidy up of admin CSS."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:961
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:980
 msgid "Tweak: Video in author box now responsive."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:962
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:981
 msgid ""
 "Tweak: Increased characters possible in address block fields from 40 to 80 characters "
 "and heading block to 200."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:963
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:982
 msgid "Tweak: Coordinates now correctly being used to generate map."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:964
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:983
 msgid "Tweak: Inspection times improved style in admin."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:965
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:984
 msgid "Tweak: Commercial rental rate now accepts decimal numbers."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:966
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:985
 msgid "Tweak: Improved google map output."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:967
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:986
 msgid "Tweak: Improved default settings on upgrade, install and multisite."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:968
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:987
 msgid "Tweak: Scripts improve site speed."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:969
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:988
 msgid "Tweak: Dashboard widget improved query."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:970
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:989
 msgid "Tweak: Front end CSS tweaks for better responsiveness."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:973
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:992
 msgid "Version 2.0.3"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:975
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:994
 msgid "Fix: Manually entered inspection capitalization fixed pM to PM."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:976
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:995
 msgid "New: French translation (Thanks to Thomas Grimaud)"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:977
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:996
 msgid "New: Finnish translation (Thanks to Turo)"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:980
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:999
 msgid "Version 2.0.2"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:982
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1001
 msgid ""
 "Fix: Added fall-back diff() function which is not present in PHP 5.2 or earlier used "
 "with the New label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:983
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1002
 msgid ""
 "Fix: Some Labels in settings were not saving correctly particularly the search widget "
 "labels."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:984
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1003
 msgid "Fix: Restored missing author profile contact form tab on author box."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:985
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1004
 msgid "Tweak: Added CSS version to admin CSS and front end CSS."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:988
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1007
 msgid "Version 2.0.1"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:990
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1009
 msgid ""
 "Fix: Attempted Twenty 15 CSS Fix but causes issues with other themes. Manual fix: "
 "Copy CSS from style-front.css to correct, margins and grid/sorter."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:991
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1010
 msgid ""
 "Fix: Restored Display of Inspection Label for properties with scheduled inspection "
 "times."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:992
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1011
 msgid "Fix: Search Widget security fix and performance improvements."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:995
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1014
 msgid "Version 2.0"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:997
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1016
 msgid "New: Extension validator."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:998
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1017
 msgid "New: Depreciated listing-meta.php into compatibility folder."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:999
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1018
 msgid "New: Depreciated author-meta.php into compatibility folder."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1000
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1019
 msgid "New: Global variables: $property, $epl_author and $epl_settings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1001
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1020
 msgid "New: Added filters for fields and groups in /lib/meta-boxes.php"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1002
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1021
 msgid ""
 "New: Property custom meta re-written into class. This was the big change to 2.0 where "
 "we completely re-wrote the output of the meta values which are now accessible using "
 "global $property variable and easy template actions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1003
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1022
 msgid ""
 "New: Property meta can now can be output using new actions for easy and quick custom "
 "template creation."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1004
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1023
 msgid "New: Reconstructed templates for single, archive & author pages"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1005
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1024
 msgid "Tweak: Removed unused price script"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1006
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1025
 msgid "Fix: Fixed warning related to static instance in strict standard modes"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1007
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1026
 msgid "New: API for extensions now support WordPress editor with validation."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1008
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1027
 msgid ""
 "New: jQuery date time picker formatting added to improve support for auction and sold "
 "listing, support for 30+ languages support."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1009
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1028
 msgid ""
 "New: Inspection time auto-formats REAXML date eg [13-Dec-2014 11:00am to 11:45am] and "
 "will no longer show past inspection times."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1010
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1029
 msgid "New: Inspection time support multiple dates written one per line."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1011
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1030
 msgid "Tweak: CSS improved with better commenting and size reduction."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1012
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1031
 msgid ""
 "New: Dashboard widget now lists all listing status so at a glance you can see your "
 "property stock."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1013
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1032
 msgid ""
 "New: Display: To enable grid, list and sorter your custom archive-listing.php "
 "template requires the new action hook epl_template_before_property_loop before the "
 "WordPress loop."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1014
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1033
 msgid ""
 "New: Display: Utility hook action hook added epl_template_after_property_loop for "
 "future updates."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1015
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1034
 msgid "New: Display: List and grid view with optional masonry effect."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1016
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1035
 msgid "New: Display: Sorter added for price high/low and date newest/oldest."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1017
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1036
 msgid "New: Auction Date formats nicely. EG [Auction Saturday 28th December at 2:00pm]."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1018
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1037
 msgid ""
 "New: Tabbed extensions page support in admin for advanced extensions like Listing "
 "Alerts."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1019
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1038
 msgid "New: Multiple author support in Author Box."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1020
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1039
 msgid ""
 "New: Search Widget - Supports multiple listing types, hold Ctrl to enable tabbed "
 "front end display."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1021
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1040
 msgid ""
 "New: Search Widget - Labels are configurable from the Display settings allowing you "
 "to set for example: Property to Buy and Rental to Rent and use a single widget to "
 "search multiple types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1022
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1041
 msgid ""
 "New: Search Widget and shortcode supports search by property ID, post Title, Land "
 "Area and Building Area."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1023
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1042
 msgid ""
 "New: Search Widget - removed extra fields from land, added labels for each property "
 "type to be shown as tab heading in search widget"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1024
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1043
 msgid ""
 "Fix: Search Widget - Optimized total queries due to search widget from 1500 + to ~40"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1025
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1044
 msgid "New: Author variables accessible using new CLASS."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1026
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1045
 msgid "New: Search short code supports array of property types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1027
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1046
 msgid ""
 "New: REAXML date format function to format date correctly when using WP All Import "
 "Pro. Usage [epl_feedsync_format_date({./@modTime})]."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1028
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1047
 msgid ""
 "New: REAXML Unit and lot formatting function for usage in the title when using WP All "
 "Import Pro. Usage [epl_feedsync_filter_sub_number({address[1]/subNumber[1]})]."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1029
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1048
 msgid ""
 "New: Global $epl_settings settings variable adds new default values on plugin update."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1030
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1049
 msgid "New: Display: Added customisable label for rental Bond/Deposit."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1031
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1050
 msgid ""
 "New: Template functions completely re-written and can now be output using actions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1032
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1051
 msgid ""
 "New: Added NEW sticker with customisable label and ability to set how long a listing "
 "displays the new label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1033
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1052
 msgid "Tweak: Compatibility fixes"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1034
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1053
 msgid "New: Bar Graph API added."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1035
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1054
 msgid ""
 "New: Graph in admin allows you to set the max bar graph value. Default are (2,000,000 "
 "sale) and (2,000 rental)."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1036
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1055
 msgid "New: Graph visually displays price and status."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1037
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1056
 msgid ""
 "New: Price graph now appears in admin pages quickly highlighting price and status "
 "visually."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1038
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1057
 msgid "New: Meta Fields: Support for unit number, lot number (land)."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1039
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1058
 msgid "New: South African ZAR currency support."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1040
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1059
 msgid "Fix: Corrected Commercial Features ID Spelling"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1041
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1060
 msgid ""
 "Tweak: YouTube video src to id function is replaced with better method which handles "
 "multiple YouTube video formats including shortened & embedded format"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1042
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1061
 msgid "New: Adding Sold Date processing"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1043
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1062
 msgid "Tweak: Updated shortcode templates"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1044
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1063
 msgid "Tweak: Global $epl_author."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1045
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1064
 msgid "Tweak: Fixed content/ into EPL_PATH_TEMPLATES_CONTENT"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1046
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1065
 msgid "New: Support for older extensions added"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1047
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1066
 msgid "New: Extension offers in menus general tab"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1048
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1067
 msgid ""
 "Tweak: Renamed user profile options section to [Easy Property Listings: Author Box "
 "Profile]."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1049
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1068
 msgid "Tweak: Added better Bond/Deposit for rentals labels."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1050
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1069
 msgid ""
 "Fix: Deprecated author-meta.php in compatibility folder, class-author-meta.php has "
 "been created which will be used in place of author-meta.php & its variables in all "
 "author templates"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1051
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1070
 msgid ""
 "New: Added template functions for author meta class, modified templates lib/templates/"
 "content/content-author-box-simple-card.php lib/templates/content/content-author-box-"
@@ -4425,512 +4492,512 @@ msgid ""
 "functions based on author meta class instead of variables from author-meta.php"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1052
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1071
 msgid ""
 "New: author-meta.php depreciated and moved to compatibility directory. Variables "
 "globally available using $epl_author variable."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1053
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1072
 msgid ""
 "Tweak: listing-meta.php depreciated and moved to compatibility directory. Variables "
 "globally available with $property variable."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1054
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1073
 msgid ""
 "Tweak: Added Listing not Found to default templates when search performed with no "
 "results."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1055
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1074
 msgid "Tweak: Improved Google maps address output for addresses containing # and /."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1056
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1075
 msgid ""
 "Fix: Listing Pages now have better responsive support for small screen devices like "
 "iPhone."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1057
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1076
 msgid ""
 "Fix: Default templates for Genesis and TwentyTwelve now show Listing Not Found when a "
 "search result returns empty."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1058
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1077
 msgid "Fix: Purged translations in epl.pot file."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1059
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1078
 msgid "Fix: Search Widget and short code drastically reduces database queries."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1060
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1079
 msgid ""
 "New: Templates are now able to be saved in active theme folder /easypropertylistings "
 "and edited. Plugin will use these first and fall back to plugin if not located in "
 "theme folder."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1061
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1080
 msgid "Fix: Extensions Notification and checker updated"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1062
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1081
 msgid "New: updated author templates to use new author meta class"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1063
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1082
 msgid ""
 "Fix: Added prefix to CSS tab-content class. Now epl-tab-content for compatibility."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1064
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1083
 msgid "New: Update user.php"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1065
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1084
 msgid "Tweak: Improved internal documentation and updated screens."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1066
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1085
 msgid "Tweak: Improved descriptions on author pages."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1067
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1086
 msgid "Tweak: Better permalink flushing on activation, deactivation and install."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1068
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1087
 msgid "Tweak: Extensive changes to admin descriptions and labels."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1069
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1088
 msgid "Tweak: Optimising the php loading of files and scripts."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1070
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1089
 msgid "New: Define EPL_RUNNING added for extensions to check if plugin is active."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1071
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1090
 msgid "New: New options added to setting array when plugin is updated."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1072
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1091
 msgid ""
 "New: Old functions and files moved to plug-in /compatibility folder to ensure old "
 "code still works."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1073
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1092
 msgid "New: Meta Location Label."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1074
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1093
 msgid "New: Service banners on settings page."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1075
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1094
 msgid "New: Saving version number so when updating new settings are added."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1076
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1095
 msgid ""
 "New: iCal functionality for REAXML formatted inspection dates. Further improvements "
 "coming for manual date entry. "
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1077
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1096
 msgid "New: Extensions options pages now with tabs for easier usage."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1078
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1097
 msgid "New: Added ID classes to admin pages and meta fields."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1079
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1098
 msgid "New: Filters to adjust land and building sizes from number to select fields."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1080
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1099
 msgid ""
 "Tweak: Moved old extensions options page to compatibility folder so older extensions "
 "still work as expected."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1081
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1100
 msgid ""
 "New: Search Widget - Added filter for land min & max fields in listing search widget"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1082
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1101
 msgid ""
 "New: Search Widget - Added filter for building min & max fields in listing search "
 "widget"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1083
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1102
 msgid "Fix: For session start effecting certain themes"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1084
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1103
 msgid "New: Land sizes now allow up to 5 decimal places"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1085
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1104
 msgid "New: Search Widget - Custom submit label"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1086
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1105
 msgid "New: Search Widget - Can search by title in property ID / Address field"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1087
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1106
 msgid "New: Added Russian Translation"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1090
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1109
 msgid "Version 1.2.1"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1092
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1111
 msgid "Fix: Search Widget not working on page 2 of archive page in some instances"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1093
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1112
 msgid ""
 "Fix: Property feature list Toilet and New Construction now display in list when ticked"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1094
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1113
 msgid "Fix: EPL - Listing widget was not displaying featured listings"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1095
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1114
 msgid ""
 "Fix: Allowed to filter by commercial_listing_type in [listing_category] shortcode"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1096
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1115
 msgid "Fix: Updated templates to display Search Results when performing search"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1097
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1116
 msgid "Fix: No longer show Bond when viewing rental list in admin"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1098
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1117
 msgid "Fix: Open for inspection sticker now appears on rental properties"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1099
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1118
 msgid "New: Added initial Dutch translation."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1102
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1121
 msgid "Version 1.2"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1104
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1123
 msgid "New: Plug in Activation process flushes permalinks"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1105
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1124
 msgid "New: Plug in deactivation flushes permalinks"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1106
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1125
 msgid "New: Shortcode [listing_search]"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1107
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1126
 msgid "New: Shortcode [listing_feature]"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1108
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1127
 msgid ""
 "New: Shortcode [listing_open] replaces [home_open] shortcode. Retained [home_open] "
 "for backward compatibility, however adjust your site. "
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1109
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1128
 msgid ""
 "New: Listing shortcodes allow for default template display if registered by adding "
 "template=\"slim\" to the shortcode."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1110
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1129
 msgid "New: Translation support now correctly loads text domain epl"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1111
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1130
 msgid "New: Added translation tags to all test elements for better translation support"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1112
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1131
 msgid "New: Updated source epl.pot translation file for translations"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1113
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1132
 msgid "New: Added very rough Italian translation"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1114
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1133
 msgid ""
 "New: Wrapped Featured image in action to allow for easy removal and/or replacement"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1115
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1134
 msgid "Fix: Undefined errors when debug is active"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1116
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1135
 msgid "New: Added new CSS classes to widgets for consistent usage"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1117
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1136
 msgid "Tweak: Admin CSS tweaks to define sections in admin"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1118
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1137
 msgid "Fix: CSS for TwentyThirteen style CSS using .sidebar container"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1119
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1138
 msgid "Fix: CSS for responsive shortcode"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1120
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1139
 msgid ""
 "New: Added options to hide/ show various options to EPL - Listing widget: Property "
 "Headline, Excerpt, Suburb/Location Label, Street Address, Price, Read More Button"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1121
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1140
 msgid "New: Added customisable \"Read More\" label to EPL - Listing widget"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1122
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1141
 msgid "New: Added excerpt to EPL - Listing widget"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1123
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1142
 msgid "New: Added options to remove search options from EPL - Listing Search widget"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1124
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1143
 msgid "New: Added consistent CSS classes to shortcodes for responsive shortcode"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1125
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1144
 msgid ""
 "New: Date processing function for use with WP All Import when importing REAXML files. "
 "Some imports set the current date instead of the date from the REAXML file. Usage in "
 "WP All Import Post Date is: [epl_feedsync_format_date({./@modTime})]"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1126
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1145
 msgid ""
 "Tweak: Added additional CSS classes to admin menu pages to extensions can be better "
 "distinguished when installed and activated"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1127
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1146
 msgid "Fix: Registering custom template actions now works correctly"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1128
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1147
 msgid "New: Added additional CSS classes to template files"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1129
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1148
 msgid ""
 "Fix: Changed property not found wording when using search widget and listing not "
 "found. "
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1130
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1149
 msgid "Tweak: Added defaults to widgets to prevent errors when debug is on"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1131
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1150
 msgid "New: Added WordPress editor support in admin for use with extensions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1132
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1151
 msgid "New: Added textarea support in admin for use with extensions."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1133
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1152
 msgid ""
 "New: Filters added for all select options on add listing pages which allows for full "
 "customisation through simple function"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1134
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1153
 msgid "New: Added rent period, Day, Daily, Month, Monthly to rental listing types"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1135
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1154
 msgid "New: Added property_office_id meta field"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1136
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1155
 msgid "New: Added property_address_country meta field"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1137
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1156
 msgid "Tweak: Allowed for decimal in bathrooms to allow for 1/2 baths eg 1.5"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1138
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1157
 msgid ""
 "New: Added mini map to listing edit screen. Will display mini map in address block "
 "when pressing green coordinates button."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1139
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1158
 msgid ""
 "Fix: Updated admin columns for commercial_land listing type to match other listing "
 "type"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1140
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1159
 msgid "Fix: Swapped bedrooms/bathroom label on hover"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1141
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1160
 msgid ""
 "New: Added filter epl_listing_meta_boxes which allows additional meta boxes to be "
 "added through filter"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1144
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1163
 msgid "Version 1.1.1"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1146
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1165
 msgid ""
 "New: Internationalisation support to enable customizing of post types: slug, archive, "
 "rewrite, labels, listing categories for meta_types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1147
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1166
 msgid ""
 "New: Created filters for listing meta select fields: property_category, "
 "property_rural_category, property_commercial_category, property_land_category."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1148
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1167
 msgid ""
 "New: Created filters for each of the seven custom post types: labels, supports, slug, "
 "archive, rewrite, seven custom post types."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1149
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1168
 msgid ""
 "New: Shortcode [listing_category] This shortcode allows for you to output a list of "
 "listings by type and filter them by any available meta key and value."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1150
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1169
 msgid "Tweak: Updated search widget for filtered property_categories."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1151
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1170
 msgid "Fix: Listing categories were showing key, now showing value."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1152
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1171
 msgid ""
 "Fix: Settings were not showing up after saving, second refresh required setting "
 "variable to reload."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1155
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1174
 msgid "Version 1.1"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1157
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1176
 msgid "First official release!"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1163
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1182
 msgid "Go to Easy Property Listings Settings"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1187
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1206
 msgid "Real Estate Tools for WordPress"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1195
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1214
 msgid "Quick Start Guide"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1197
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1216
 msgid ""
 "Use the tips below to get started using Easy Property Listings. You will be up and "
 "running in no time!"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1201
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1220
 msgid "Activate the listing types you need & configure the plugin general settings"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1202
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1244
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1221
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1263
 msgid "Create a blank page for each activated listing type"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1203
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1222
 msgid "Publish your first listing for testing your theme setup"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1205
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1224
 msgid "Setup your theme to work with the plugin"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1207
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1226
 #: lib/includes/admin/menus/menu-help.php:42
 msgid "Visit Support"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1214
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1233
 msgid "Activate the listing types you need"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1220
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1239
 msgid ""
 "Visit the general settings page and enable the listing types you need. Once you have "
 "pressed save visit the Permalinks page to re-fresh your sites permalinks."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1222
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1241
 msgid ""
 "Instead of classifying everything as a property, Easy Property Listings allows you to "
 "separate the different listing types which is better for SEO and RSS feeds."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1224
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1243
 msgid "Supported Listing Types"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1226
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1245
 #: lib/includes/functions.php:155
 msgid "Property (Residential)"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1227
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1246
 #: lib/includes/functions.php:157 lib/includes/functions.php:1383
 #: lib/includes/functions.php:1385 lib/post-types/post-type-rental.php:29
 #: lib/updates/epl-1.3.1.php:6 lib/widgets/widget-admin-dashboard.php:83
 msgid "Rental"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1228
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1247
 #: lib/includes/functions.php:156 lib/includes/functions.php:1377
 #: lib/includes/functions.php:1379 lib/includes/install.php:66
 #: lib/post-types/post-type-land.php:28 lib/post-types/post-type-land.php:29
@@ -4939,7 +5006,7 @@ msgstr ""
 msgid "Land"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1229
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1248
 #: lib/includes/functions.php:158 lib/includes/functions.php:1389
 #: lib/includes/functions.php:1391 lib/includes/install.php:68
 #: lib/post-types/post-type-rural.php:28 lib/post-types/post-type-rural.php:29
@@ -4948,7 +5015,7 @@ msgstr ""
 msgid "Rural"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1230
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1249
 #: lib/includes/functions.php:159 lib/includes/functions.php:510
 #: lib/includes/functions.php:1395 lib/includes/functions.php:1397
 #: lib/includes/install.php:70 lib/post-types/post-type-commercial.php:29
@@ -4956,7 +5023,7 @@ msgstr ""
 msgid "Commercial"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1231
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1250
 #: lib/includes/functions.php:160 lib/includes/functions.php:1401
 #: lib/includes/functions.php:1403 lib/includes/install.php:71
 #: lib/post-types/post-type-commercial_land.php:30 lib/updates/epl-1.3.1.php:10
@@ -4964,7 +5031,7 @@ msgstr ""
 msgid "Commercial Land"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1232
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1251
 #: lib/includes/functions.php:161 lib/includes/functions.php:1407
 #: lib/includes/functions.php:1409 lib/includes/install.php:69
 #: lib/post-types/post-type-business.php:30 lib/updates/epl-1.3.1.php:8
@@ -4972,58 +5039,58 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1249
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1268
 msgid ""
 "Doing this allows you to add \"Property\", \"Land\" and \"Rental\" pages to your "
 "WordPress menu. Add a new page for each listing type you activated."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1251
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1270
 msgid ""
 "For example, lets say you have activated: Property, Rental and Land. Create three "
 "pages, one called \"Property\", another \"Land\" and the third \"Rental\" these will "
 "be the custom post type slugs/permalinks eg: property, rental and land."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1253
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1272
 msgid ""
 "Publish a test \"Property Listing\" and visit your new property page and you will see "
 "the new property and others you have created."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1255
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1274
 msgid ""
 "Now you can rename them to whatever you like eg: \"For Sale\", \"For Rent\" etc, but "
 "leave the slug/permalink as it was,"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1255
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1274
 msgid "this is very important."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1268
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1287
 msgid "Publish Your First Listing"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1277
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1296
 msgid "Title & Author"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1284
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1303
 msgid "Use the full listing address as the title."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1286
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1305
 msgid ""
 "When a property is being sold the \"heading\" is frequently changed and can cause "
 "permalink issues. Not to mention the search engine benefits."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1288
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1307
 msgid "Author or Primary Real Estate Agent"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1289
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1308
 msgid ""
 "Select the author to show the name of the agent who has listed the property with "
 "their contact details. For best results each real estate agent should have their own "
@@ -5031,41 +5098,41 @@ msgid ""
 "and in widgets."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1298
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1317
 msgid "Gallery and Featured Image"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1303
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1322
 msgid "Gallery"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1304
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1323
 #: lib/includes/admin/menus/menu-help.php:148
 msgid "Add a gallery of images to your listings with the WordPress Add Media button."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1306
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1325
 msgid "You can automatically output a gallery from the Display options page."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1308
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1327
 msgid ""
 "If set to automatic, just upload your images to the listing and press x to close the "
 "media upload box once the images are attached to the listing. You can also easily "
 "adjust the number of gallery columns from the plugin Display options."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1310
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1329
 msgid "Gallery Light Box"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1311
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1330
 msgid ""
 "Using a light box plug-in like Easy FancyBox, your automatic gallery images will use "
 "the light box effect."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1322
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1341
 #: lib/includes/admin/menus/menu-help.php:161 lib/meta-boxes/meta-boxes.php:101
 #: lib/post-types/post-type-business.php:86 lib/post-types/post-type-commercial.php:84
 #: lib/post-types/post-type-commercial_land.php:85 lib/post-types/post-type-land.php:85
@@ -5074,175 +5141,175 @@ msgstr ""
 msgid "Listing Details"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1328
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1347
 #: lib/includes/admin/menus/menu-help.php:163 lib/meta-boxes/meta-boxes.php:113
 msgid "Heading"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1329
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1348
 #: lib/includes/admin/menus/menu-help.php:164
 msgid "Enter the descriptive listing headline like \"Great Property with Views\"."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1331
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1350
 #: lib/includes/admin/menus/menu-help.php:166 lib/meta-boxes/meta-boxes.php:141
 #: lib/post-types/post-types.php:85
 msgid "Second Listing Agent"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1332
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1351
 #: lib/includes/admin/menus/menu-help.php:167
 msgid ""
 "If the listing has two real estate agents marketing it, enter their WordPress user "
 "name here. The primary agent is the post Author."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1334
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1353
 #: lib/includes/admin/menus/menu-help.php:169
 msgid "Inspection Times"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1335
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1354
 msgid ""
 "Now supports multiple inspection times, add one per line. Past inspection dates will "
 "not display when using the new format."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1337
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1356
 msgid ""
 "The output is now wrapped in an iCal format so clicking on the date will open the "
 "users calendar."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1347
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1366
 #: lib/includes/admin/menus/menu-help.php:181
 msgid "Search by location"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1352
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1371
 #: lib/includes/admin/menus/menu-help.php:183
 msgid ""
 "Although the address details are added into the Property Address box the location "
 "search you also need to add the City/Suburb to the location search taxonomy."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1353
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1372
 #: lib/includes/admin/menus/menu-help.php:184
 msgid ""
 "This works like post tags and will populate the search widget/shortcode with your "
 "listings and it will automatically filter out options if no listings have that option."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1365
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1384
 msgid "Configure your theme"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1366
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1385
 msgid ""
 "We have done our best to integrate Easy Property Listings with all WordPress themes."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1371
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1390
 #: lib/includes/functions.php:1481
 msgid "Theme Compatibility"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1372
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1391
 msgid ""
 "Once you add a listing and if your page is really wide or your sidebar is under the "
 "content enable Theme Compatibility mode from settings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1374
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1393
 msgid ""
 "Review your listing and if you are seeing double images, hop back over to Settings "
 "page and either disable the theme feature image or the one provided by Easy Property "
 "Listings."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1376
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1395
 msgid "Shortcodes"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1378
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1397
 msgid ""
 "The featured image settings have no impact on the Easy Property Listings shortcodes "
 "and widgets."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1383
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1402
 msgid "Theme Compatibility not required for some themes"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1385
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1404
 msgid "iThemes Builder Themes"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1386
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1405
 msgid "Genesis Framework by StudioPress"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1387
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1406
 msgid "Headway Theme Framework"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1388
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1407
 msgid "Twenty 12, 13, 14 &#38; 15 by WordPress."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1389
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1408
 msgid "Many others, add a listing and see how it looks."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1391
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1410
 msgid "We have a selection of pre configured templates here for many popular themes"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1391
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1410
 msgid "here"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1397
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1416
 msgid "Advanced instructions"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1400
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1419
 msgid "theme setup instructions can be found here"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1401
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1420
 msgid "custom templates"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1402
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1421
 #, php-format
 msgid "Detailed %s."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1403
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1422
 #, php-format
 msgid "How to create your own %s."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1409
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1428
 msgid "Stuck getting your theme to work?"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1410
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1429
 msgid ""
 "Not all themes follow modern WordPress coding standards and these may take a little "
 "more time and experience to get working. If you just can not get it to work, visit"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1410
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1429
 msgid "premium support"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1410
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1429
 msgid "and fill out a theme support request."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1412
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1431
 msgid ""
 "If the theme is available in the WordPress.org theme directory let us know the theme "
 "name and URL where we can download it in your support ticket. If its a premium theme "
@@ -5250,60 +5317,60 @@ msgid ""
 "download link to it on a file sharing site like Dropbox."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1414
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1433
 msgid "Need Help?"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1418
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1437
 msgid "Premium Support"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1419
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1438
 #, php-format
 msgid ""
 "We do our best to provide the best support we can. If you encounter a problem or have "
 "a question, post a question in the <a href=\"%s\">support forums</a>."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1423
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1442
 msgid "Need Even Faster Support?"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1424
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1443
 msgid ""
 "<a href=\"https://easypropertylistings.com.au/support-ticket/\">Priority Support "
 "forums</a> are there for customers that need faster and/or more in-depth assistance."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1428
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1447
 msgid "Documentation and Short Codes"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1429
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1448
 msgid "Read the"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1429
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1448
 msgid "documentation"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1429
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1448
 msgid " and instructions on how to use the included"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1429
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1448
 msgid "shortcodes"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1438
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1457
 msgid "Stay Up to Date"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1439
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1458
 msgid "Get Notified of Extension Releases"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1440
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1459
 msgid ""
 "New extensions that make Easy Property Listings even more powerful are released "
 "nearly every single week. Subscribe to the newsletter to stay up to date with our "
@@ -5311,41 +5378,41 @@ msgid ""
 "a> to ensure you do not miss a release!"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1442
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1461
 msgid "Get Alerted About New Tutorials"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1443
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1462
 msgid ""
 "<a href=\"http://eepurl.com/TRO9f\" target=\"_blank\">Sign up now</a> to hear about "
 "the latest tutorial releases that explain how to take Easy Property Listings further."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1446
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1465
 msgid "Sliders"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1447
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1466
 msgid "Brochures"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1450
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1469
 msgid "Agent/Staff Directory"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1452
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1471
 msgid "Add-On Store"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1454
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1473
 msgid "Extend With Extensions"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1455
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1474
 msgid "18 Extensions and many more coming"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1456
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1475
 #, php-format
 msgid ""
 "Add-on plug ins are available that greatly extend the default functionality of Easy "
@@ -5353,27 +5420,27 @@ msgid ""
 "more. Visit the %s to further enhance your real estate website."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1458
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1477
 msgid "Visit the Extension Store"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1459
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1478
 msgid "The Extensions store"
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1459
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1478
 msgid ""
 "has a list of all available extensions to make your real estate website even better."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1484
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1503
 msgid ""
 "Easy Property Listings is created by a worldwide team of developers who aim to "
 "provide the #1 property listings platform for managing your real estate business "
 "through WordPress."
 msgstr ""
 
-#: lib/includes/admin/menus/class-epl-menu-welcome.php:1511
+#: lib/includes/admin/menus/class-epl-menu-welcome.php:1530
 #: lib/includes/class-epl-custom-post-type.php:410
 #: lib/includes/class-epl-custom-post-type.php:512
 #, php-format
@@ -5740,7 +5807,7 @@ msgstr ""
 msgid "Call"
 msgstr ""
 
-#: lib/includes/class-epl-contact.php:679 lib/includes/template-functions.php:2088
+#: lib/includes/class-epl-contact.php:679 lib/includes/template-functions.php:2157
 msgid "Listing"
 msgstr ""
 
@@ -5851,9 +5918,9 @@ msgid "Show all %s"
 msgstr ""
 
 #: lib/includes/class-epl-property-meta.php:299
-#: lib/includes/class-epl-property-meta.php:571
-#: lib/includes/class-epl-property-meta.php:627
-#: lib/includes/class-epl-property-meta.php:671 lib/meta-boxes/meta-boxes.php:39
+#: lib/includes/class-epl-property-meta.php:613
+#: lib/includes/class-epl-property-meta.php:669
+#: lib/includes/class-epl-property-meta.php:713 lib/meta-boxes/meta-boxes.php:39
 #: lib/meta-boxes/meta-boxes.php:54 lib/widgets/widget-admin-dashboard.php:133
 #: lib/widgets/widget-admin-dashboard.php:155
 msgid "Auction"
@@ -5863,35 +5930,36 @@ msgstr ""
 msgid "now"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:535
-#: lib/includes/class-epl-property-meta.php:630 lib/includes/functions.php:1237
+#: lib/includes/class-epl-property-meta.php:577
+#: lib/includes/class-epl-property-meta.php:672 lib/includes/functions.php:1237
 #: lib/includes/install.php:60
 msgid "POA"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:675
+#: lib/includes/class-epl-property-meta.php:717
 msgid "For Sale and Lease"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:922
-#: lib/includes/class-epl-property-meta.php:923
-#: lib/includes/class-epl-property-meta.php:924
+#: lib/includes/class-epl-property-meta.php:950
+#: lib/includes/class-epl-property-meta.php:951
+#: lib/includes/class-epl-property-meta.php:952
 msgid "Built"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1016
+#: lib/includes/class-epl-property-meta.php:1044
 msgid "garage"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1034
+#: lib/includes/class-epl-property-meta.php:1062
 msgid "carport"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1093
+#: lib/includes/class-epl-property-meta.php:1121
 msgid "Alarm System"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1137
+#: lib/includes/class-epl-property-meta.php:1141
+#: lib/includes/class-epl-property-meta.php:1168
 msgid "m&#178;"
 msgstr ""
 
@@ -6410,12 +6478,12 @@ msgstr ""
 msgid "Listing view type"
 msgstr ""
 
-#: lib/includes/functions.php:1343 lib/includes/template-functions.php:1368
+#: lib/includes/functions.php:1343 lib/includes/template-functions.php:1437
 #: lib/widgets/widget-listing.php:304
 msgid "List"
 msgstr ""
 
-#: lib/includes/functions.php:1344 lib/includes/template-functions.php:1370
+#: lib/includes/functions.php:1344 lib/includes/template-functions.php:1439
 msgid "Grid"
 msgstr ""
 
@@ -6750,7 +6818,7 @@ msgstr ""
 msgid "Next Page &raquo;"
 msgstr ""
 
-#: lib/includes/template-functions.php:627 lib/includes/template-functions.php:870
+#: lib/includes/template-functions.php:627 lib/includes/template-functions.php:898
 #: lib/meta-boxes/meta-boxes.php:1252
 msgid "Plus Outgoings"
 msgstr ""
@@ -6759,93 +6827,93 @@ msgstr ""
 msgid "Available from"
 msgstr ""
 
-#: lib/includes/template-functions.php:851
+#: lib/includes/template-functions.php:879
 msgid "Property Features"
 msgstr ""
 
-#: lib/includes/template-functions.php:905 lib/meta-boxes/meta-boxes.php:1297
+#: lib/includes/template-functions.php:951 lib/meta-boxes/meta-boxes.php:1297
 msgid "Commercial Features"
 msgstr ""
 
-#: lib/includes/template-functions.php:931 lib/meta-boxes/meta-boxes.php:1103
+#: lib/includes/template-functions.php:998 lib/meta-boxes/meta-boxes.php:1103
 msgid "Rural Features"
 msgstr ""
 
-#: lib/includes/template-functions.php:1018
+#: lib/includes/template-functions.php:1087
 msgid "Price: High to Low"
 msgstr ""
 
-#: lib/includes/template-functions.php:1026
+#: lib/includes/template-functions.php:1095
 msgid "Price: Low to High"
 msgstr ""
 
-#: lib/includes/template-functions.php:1035
+#: lib/includes/template-functions.php:1104
 msgid "Date: Newest First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1044
+#: lib/includes/template-functions.php:1113
 msgid "Date: Oldest First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1051
+#: lib/includes/template-functions.php:1120
 msgid "Status : Current First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1060
+#: lib/includes/template-functions.php:1129
 msgid "Status : Sold/Leased First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1069
+#: lib/includes/template-functions.php:1138
 msgid " A-Z"
 msgstr ""
 
-#: lib/includes/template-functions.php:1078
+#: lib/includes/template-functions.php:1147
 msgid " Z-A"
 msgstr ""
 
-#: lib/includes/template-functions.php:1105
+#: lib/includes/template-functions.php:1174
 msgid "Sort"
 msgstr ""
 
-#: lib/includes/template-functions.php:1169
+#: lib/includes/template-functions.php:1238
 msgid "About"
 msgstr ""
 
-#: lib/includes/template-functions.php:1170
+#: lib/includes/template-functions.php:1239
 msgid "Bio"
 msgstr ""
 
-#: lib/includes/template-functions.php:1171
+#: lib/includes/template-functions.php:1240
 msgid "Video"
 msgstr ""
 
-#: lib/includes/template-functions.php:1917
+#: lib/includes/template-functions.php:1986
 msgid "There is no excerpt because this is a protected post."
 msgstr ""
 
-#: lib/includes/template-functions.php:2077
+#: lib/includes/template-functions.php:2146
 #, php-format
 msgid "Property in %s"
 msgstr ""
 
-#: lib/includes/template-functions.php:2080
+#: lib/includes/template-functions.php:2149
 msgid "Search Result"
 msgstr ""
 
-#: lib/includes/template-functions.php:2139
+#: lib/includes/template-functions.php:2208
 #: lib/templates/content/shortcode-listing.php:49
 msgid "Nothing found, please check back later."
 msgstr ""
 
-#: lib/includes/template-functions.php:2142
+#: lib/includes/template-functions.php:2211
 msgid "Nothing currently scheduled for inspection, please check back later."
 msgstr ""
 
-#: lib/includes/template-functions.php:2157
+#: lib/includes/template-functions.php:2226
 msgid "Listing not Found"
 msgstr ""
 
-#: lib/includes/template-functions.php:2158
+#: lib/includes/template-functions.php:2227
 msgid "Listing not found, expand your search criteria and try again."
 msgstr ""
 

--- a/lib/includes/admin/menus/class-epl-menu-welcome.php
+++ b/lib/includes/admin/menus/class-epl-menu-welcome.php
@@ -249,6 +249,25 @@ class EPL_Welcome {
 
 				<div class="feature-section">
 
+					<h4><?php _e( 'Version 3.1.12', 'easy-property-listings'  );?></h4>
+
+					<ul>
+						<li><?php _e( 'New: Filter epl_property_land_area_unit_label for Land Unit Label Filter.', 'easy-property-listings'  );?></li>
+						<li><?php _e( 'New: Filter epl_property_building_area_unit_label for Building Unit Label Filter.', 'easy-property-listings'  );?></li>
+						<li><?php _e( 'New: Filter epl_the_property_feature_list_before before the features list.', 'easy-property-listings'  );?></li>
+						<li><?php _e( 'New: Filter epl_the_property_feature_list_before_common_features before the common features list.', 'easy-property-listings'  );?></li>
+						<li><?php _e( 'New: Filter epl_the_property_feature_list_before_additional_features before the additional features list.', 'easy-property-listings'  );?></li>
+						<li><?php _e( 'New: Filter epl_the_property_feature_list_after for after the output of the features list.', 'easy-property-listings'  );?></li>
+						<li><?php _e( 'Tweak: Property, Rural, Commercial Category output to secondary heading.', 'easy-property-listings'  );?></li>
+						<li><?php _e( 'Tweak: Altered land sqm output to m2.', 'easy-property-listings'  );?></li>
+						<li><?php _e( 'Tweak: Shortcode [listing_auction] now only displays auction listings.', 'easy-property-listings'  );?></li>
+						<li><?php _e( 'Fix: Property Category now outputs to feature list.', 'easy-property-listings'  );?></li>
+						<li><?php _e( 'Fix: Rural Category now outputs to feature list.', 'easy-property-listings'  );?></li>
+						<li><?php _e( 'Fix: Commercial Category now outputs to feature list.', 'easy-property-listings'  );?></li>
+						<li><?php _e( 'Fix: Empty Commercial Features heading no longer outputs heading if values are empty.', 'easy-property-listings'  );?></li>
+						<li><?php _e( 'Fix: Empty Rural Features heading no longer outputs heading if values are empty.', 'easy-property-listings'  );?></li>
+					</ul>
+
 					<h4><?php _e( 'Version 3.1.11', 'easy-property-listings'  );?></h4>
 
 					<ul>

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -475,8 +475,16 @@ class EPL_Property_Meta {
 	 * @since 2.0
 	 * @return string
 	 */
-	public function get_property_category () {
-		return apply_filters('epl_get_property_category',epl_listing_meta_property_category_value( $this->get_property_meta('property_category') ));
+	public function get_property_category ( $tag = '' ) {
+
+		$property_category =	epl_listing_meta_property_category_value( $this->get_property_meta('property_category') );
+
+		if ( $tag != '' ) {
+
+			$property_category = '<'.$tag.' class="property-category">' . __( $property_category,'easy-property-listings' ) . '</'.$tag.'>';
+		}
+
+		return apply_filters('epl_get_property_category', $property_category );
 	}
 
 	/**

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -473,18 +473,52 @@ class EPL_Property_Meta {
 	 * Listing Category
 	 *
 	 * @since 2.0
+	 * @param string $tag HTML wrapper type, default div
+	 * @param string $class name, default property-category
 	 * @return string
 	 */
-	public function get_property_category ( $tag = '' ) {
+	public function get_property_category( $tag = 'div' , $class = 'property-category' ) {
 
 		$property_category =	epl_listing_meta_property_category_value( $this->get_property_meta('property_category') );
 
-		if ( $tag != '' ) {
-
-			$property_category = '<'.$tag.' class="property-category">' . __( $property_category,'easy-property-listings' ) . '</'.$tag.'>';
+		if ( $tag != 'none' || $tag != '' ) {
+			$property_category = '<'.$tag.' class="' . $class . '">' . __( $property_category,'easy-property-listings' ) . '</'.$tag.'>';
 		}
-
 		return apply_filters('epl_get_property_category', $property_category );
+	}
+
+	/**
+	 * Get Commercial Category
+	 *
+	 * @since 2.0
+	 * @param string $tag HTML wrapper type, default div
+	 * @param string $class name, default commercial-category
+	 * @return string
+	 */
+	public function get_property_commercial_category( $tag = 'div' , $class = 'commercial-category' ) {
+		$property_commercial_category = epl_listing_load_meta_commercial_category_value( $this->get_property_meta('property_commercial_category') );
+
+		if ( $tag != 'none' || $tag != '' ) {
+			$property_commercial_category = '<'.$tag.' class="' . $class . '">' . __($property_commercial_category,'easy-property-listings' ) . '</'.$tag.'>';
+		}
+		return apply_filters('epl_get_property_commercial_category',$property_commercial_category);
+	}
+
+	/**
+	 * Get Rural Category
+	 *
+	 * @since 3.1.12
+	 * @param string $tag HTML wrapper type, default div
+	 * @param string $class name, default rural-category
+	 * @return string
+	 */
+	public function get_property_rural_category( $tag = 'div' , $class = 'rural-category' ) {
+		$property_rural_category = epl_listing_load_meta_rural_category_value( $this->get_property_meta('property_rural_category') );
+
+		if ( $tag != 'none' || $tag != '' ) {
+			$property_rural_category = '<'.$tag.' class="' . $class . '">' . __( $property_rural_category , 'easy-property-listings' ) . '</'.$tag.'>';
+		}
+		return apply_filters( 'epl_get_property_rural_category' , $property_rural_category );
 	}
 
 	/**
@@ -904,34 +938,6 @@ class EPL_Property_Meta {
 	}
 
 	/**
-	 * Get Commercial Category
-	 *
-	 * @since 2.0
-	 * @param string $tag HTML wrapper type, default div
-	 * @return string
-	 */
-	public function get_property_commercial_category( $tag = 'div' ) {
-		$property_commercial_category = epl_listing_load_meta_commercial_category_value( $this->get_property_meta('property_commercial_category') );
-		$property_commercial_category = '<'.$tag.' class="commercial-category">' . __($property_commercial_category,'easy-property-listings' ) . '</'.$tag.'>';
-
-		return apply_filters('epl_get_property_commercial_category',$property_commercial_category);
-	}
-
-	/**
-	 * Get Rural Category
-	 *
-	 * @since 3.1.12
-	 * @param string $tag HTML wrapper type, default div
-	 * @return string
-	 */
-	public function get_property_rural_category( $tag = 'div' ) {
-		$property_rural_category = epl_listing_load_meta_rural_category_value( $this->get_property_meta('property_rural_category') );
-		$property_rural_category = '<'.$tag.' class="rural-category">' . __( $property_rural_category , 'easy-property-listings' ) . '</'.$tag.'>';
-
-		return apply_filters( 'epl_get_property_rural_category' , $property_rural_category );
-	}
-
-	/**
 	 * Get Year Built
 	 *
 	 * @since 2.0
@@ -1213,10 +1219,6 @@ class EPL_Property_Meta {
 			// Commercial Car Spaces : Label Issue (Returning 50 Com Car Spaces. Need to remove com
 			if($metakey == 'property_com_car_spaces'){
 				$metavalue = $metavalue.apply_filters('epl_get_property_com_car_spaces_label','' );
-			}
-
-			if($metakey == 'property_category'){
-				$metavalue = $this->get_property_category();
 			}
 
 	                switch($metavalue) {

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -1192,6 +1192,8 @@ class EPL_Property_Meta {
 		$return = '';
 
 		if( $metavalue != '' || intval($metavalue) != 0) {
+
+			// Commercial Car Spaces : Label Issue (Returning 50 Com Car Spaces. Need to remove com
 			if($metakey == 'property_com_car_spaces'){
 				$metavalue = $metavalue.apply_filters('epl_get_property_com_car_spaces_label','' );
 			}
@@ -1221,8 +1223,8 @@ class EPL_Property_Meta {
 					break;
 
 				default:
-	                        $return = '<li class="'.$this->get_class_from_metakey($metakey).'">'.__($metavalue,'easy-property-listings' ).' '.apply_filters('epl_get_'.$metakey.'_label',__($this->get_label_from_metakey($metakey), 'easy-property-listings' ) ).'</li>';
-	                    break;
+	                        	$return = '<li class="'.$this->get_class_from_metakey($metakey).'">'.__($metavalue,'easy-property-listings' ).' '.apply_filters('epl_get_'.$metakey.'_label',__($this->get_label_from_metakey($metakey), 'easy-property-listings' ) ).'</li>';
+					break;
 	                }
 		}
 		return apply_filters('epl_get_additional_features_html',$return);

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -1118,11 +1118,14 @@ class EPL_Property_Meta {
 	public function get_property_land_value( $returntype = 'i' ) {
 		$property_land_area_unit = $this->get_property_meta('property_land_area_unit');
 		if ( $property_land_area_unit == 'squareMeter' ) {
-			$property_land_area_unit = __('sqm' , 'easy-property-listings' );
+			$property_land_area_unit = __('m&#178;' , 'easy-property-listings' );
 		} else {
 			// translation for land area unit
 			$property_land_area_unit = __($property_land_area_unit , 'easy-property-listings' );
 		}
+
+		$property_land_area_unit = apply_filters( 'epl_property_land_area_unit_label' , $property_land_area_unit );
+
 		if(is_numeric($this->get_property_meta('property_land_area')) ) {
 			$label = apply_filters('epl_get_property_land_area_label',__('Land is', 'easy-property-listings' ) );
 			$return = '
@@ -1148,12 +1151,12 @@ class EPL_Property_Meta {
 			$building_unit = __($building_unit , 'easy-property-listings' );
 		}
 
+		$building_unit = apply_filters( 'epl_property_building_area_unit_label' , $building_unit );
+
 		if(intval($this->get_property_meta('property_building_area')) != 0 ) {
 			$label = apply_filters('epl_get_property_building_area_label',__('Floor Area is', 'easy-property-listings' ) );
 			$return = '
-			<li class="land-size">'.$label.' ' .
-                $this->get_property_meta('property_building_area') .' '.$building_unit.
-			'</li>';
+			<li class="land-size">'.$label.' ' . $this->get_property_meta('property_building_area') .' '.$building_unit. '</li>';
 			return apply_filters('epl_get_property_building_area_value',$return);
 		}
 

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -918,6 +918,20 @@ class EPL_Property_Meta {
 	}
 
 	/**
+	 * Get Rural Category
+	 *
+	 * @since 3.1.12
+	 * @param string $tag HTML wrapper type, default div
+	 * @return string
+	 */
+	public function get_property_rural_category( $tag = 'div' ) {
+		$property_rural_category = epl_listing_load_meta_rural_category_value( $this->get_property_meta('property_rural_category') );
+		$property_rural_category = '<'.$tag.' class="rural-category">' . __( $property_rural_category , 'easy-property-listings' ) . '</'.$tag.'>';
+
+		return apply_filters( 'epl_get_property_rural_category' , $property_rural_category );
+	}
+
+	/**
 	 * Get Year Built
 	 *
 	 * @since 2.0

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -718,7 +718,20 @@ add_action('epl_property_heading','epl_property_heading');
  */
 function epl_property_secondary_heading() {
 	global $property;
-	echo '<span class="epl-property-category">' . $property->get_property_category() . '</span> ';
+
+
+	if ( $property->post_type == 'property' || $property->post_type == 'rental' ) {
+		echo $property->get_property_category( 'span' , 'epl-property-category' );
+	}
+
+	if ( $property->post_type == 'rural' ) {
+		echo $property->get_property_rural_category( 'span' , 'epl-rural-category' );
+	}
+
+	if ( $property->post_type == 'commercial' || $property->post_type == 'commercial_land' ) {
+		echo $property->get_property_commercial_category( 'span' , 'epl-commercial-category' );
+	}
+
 	if($property->get_property_meta('property_status') == 'sold'){
 		echo '<span class="sold-status">'.$property->label_sold.'</span>';
 	}
@@ -734,7 +747,7 @@ add_action('epl_property_secondary_heading','epl_property_secondary_heading');
  */
 function epl_property_category() {
 	global $property;
-	echo $property->get_property_category();
+	echo $property->get_property_category( 'none' );
 }
 
 /**

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -805,8 +805,8 @@ function epl_property_tab_section() {
 				'property_garage',
 				'property_carport',
 				'property_open_spaces',
-				'property_com_parking_comments',
-				'property_com_car_spaces',
+				'property_com_parking_comments', // Issue with label output
+				'property_com_car_spaces', // Issue with label output
 			);
 	$common_features = apply_filters('epl_property_common_features_list',$common_features);
 
@@ -907,19 +907,39 @@ function epl_property_tab_section_after() {
 			'property_com_highlight_3',
 			'property_com_zone',
 		);
-		foreach($features_lists as $features_list){
-			$the_property_commercial_feature_list .= $property->get_additional_commerical_features_html($features_list);
+
+		// Check for values in the commercial features
+		$commercial_value = '';
+
+		$result = array();
+
+		foreach ( $features_lists as $feature ) {
+
+			$commercial_value = $property->get_property_meta( $feature );
+
+			if ( $commercial_value != '' ) {
+				$result[] = $commercial_value;
+			}
 		}
 
-	?>
-		<div class="epl-tab-section epl-tab-section-commercial-features">
-			<h5 class="epl-tab-title epl-tab-title-commercial-features tab-title"><?php apply_filters( 'epl_property_sub_title_commercial_features' , _e('Commercial Features', 'easy-property-listings' ) ); ?></h5>
-			<div class="epl-tab-content tab-content">
-				<div class="epl-commercial-features listing-info">
-					<?php echo $the_property_commercial_feature_list; ?>
+		// Display results if $result array is not empty
+		if ( ! empty( $result ) ) {
+
+			foreach( $features_lists as $features_list ){
+				$the_property_commercial_feature_list .= $property->get_additional_commerical_features_html($features_list);
+			}
+
+		?>
+			<div class="epl-tab-section epl-tab-section-commercial-features">
+				<h5 class="epl-tab-title epl-tab-title-commercial-features tab-title"><?php apply_filters( 'epl_property_sub_title_commercial_features' , _e('Commercial Features', 'easy-property-listings' ) ); ?></h5>
+				<div class="epl-tab-content tab-content">
+					<div class="epl-commercial-features listing-info">
+						<?php echo $the_property_commercial_feature_list; ?>
+					</div>
 				</div>
 			</div>
-		</div> <?php
+		<?php
+		}
 	}
 
 	if ( $property->post_type == 'rural') {

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -814,7 +814,7 @@ function epl_property_tab_section() {
 		$the_property_feature_list .= $property->get_additional_features_html($common_feature);
 	}
 
-	$the_property_feature_list .= apply_filters('epl_the_property_feature_list_after_common_features', '' );
+	$the_property_feature_list .= apply_filters('epl_the_property_feature_list_before_additional_features', '' );
 
 	$additional_features 	= array (
 		'property_remote_garage',

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -733,7 +733,7 @@ function epl_property_secondary_heading() {
 	}
 
 	if($property->get_property_meta('property_status') == 'sold'){
-		echo '<span class="sold-status">'.$property->label_sold.'</span>';
+		echo ' <span class="sold-status">'.$property->label_sold.'</span>';
 	}
 	echo ' <span class="suburb"> - ' . $property->get_property_meta('property_address_suburb') . ' </span>';
 	echo ' <span class="state">' . $property->get_property_meta('property_address_state') . '</span>';

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -945,17 +945,36 @@ function epl_property_tab_section_after() {
 	if ( $property->post_type == 'rural') {
 		$the_property_rural_feature_list = '';
 		$features_lists = array(
-							'property_rural_fencing',
-							'property_rural_annual_rainfall',
-							'property_rural_soil_types',
-							'property_rural_improvements',
-							'property_rural_council_rates',
-							'property_rural_irrigation',
-							'property_rural_carrying_capacity',
+			'property_rural_fencing',
+			'property_rural_annual_rainfall',
+			'property_rural_soil_types',
+			'property_rural_improvements',
+			'property_rural_council_rates',
+			'property_rural_irrigation',
+			'property_rural_carrying_capacity',
 		);
-		foreach($features_lists as $features_list){
-			$the_property_rural_feature_list .= $property->get_additional_rural_features_html($features_list);
+
+		// Check for values in the rural features
+		$rural_value = '';
+
+		$result = array();
+
+		foreach ( $features_lists as $feature ) {
+
+			$rural_value = $property->get_property_meta( $feature );
+
+			if ( $rural_value != '' ) {
+				$result[] = $rural_value;
+			}
 		}
+
+
+		// Display results if $result array is not empty
+		if ( ! empty( $result ) ) {
+
+			foreach($features_lists as $features_list){
+				$the_property_rural_feature_list .= $property->get_additional_rural_features_html($features_list);
+			}
 
 	?>
 		<div class="epl-tab-section epl-tab-section-rural-features">
@@ -966,7 +985,9 @@ function epl_property_tab_section_after() {
 				</div>
 			</div>
 		</div>
-	<?php }
+		<?php
+		}
+	}
 }
 add_action('epl_property_tab_section_after','epl_property_tab_section_after');
 

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -780,7 +780,11 @@ add_action('epl_property_content_after','epl_property_video_callback' , 10 , 1);
 function epl_property_tab_section() {
 	global $property;
 	$post_type = $property->post_type;
-	$the_property_feature_list = '';
+	$the_property_feature_list = apply_filters('epl_the_property_feature_list_before', '' );
+
+	if ( 'property' == $post_type || 'rental' == $post_type || 'rural' == $post_type ) {
+		$the_property_feature_list .= $property->get_property_category('li');
+	}
 
 	if ( 'commercial' == $post_type || 'commercial_land' == $post_type || 'business' == $post_type ) {
 		$the_property_feature_list .= $property->get_property_commercial_category('li');
@@ -791,6 +795,9 @@ function epl_property_tab_section() {
 	$the_property_feature_list .= $property->get_property_air_conditioning('l').' '.$property->get_property_pool('l');
 	$the_property_feature_list .= $property->get_property_security_system('l').' '.$property->get_property_land_value('l');
 	$the_property_feature_list .= $property->get_property_building_area_value('l').' '.$property->get_property_new_construction('l');
+
+	$the_property_feature_list .= apply_filters('epl_the_property_feature_list_before_common_features', '' );
+
 	$common_features = array(
 				'property_toilet',
 				'property_ensuite',
@@ -800,13 +807,15 @@ function epl_property_tab_section() {
 				'property_open_spaces',
 				'property_com_parking_comments',
 				'property_com_car_spaces',
-				'property_category',
 			);
 	$common_features = apply_filters('epl_property_common_features_list',$common_features);
 
 	foreach($common_features as $common_feature){
 		$the_property_feature_list .= $property->get_additional_features_html($common_feature);
 	}
+
+	$the_property_feature_list .= apply_filters('epl_the_property_feature_list_after_common_features', '' );
+
 	$additional_features 	= array (
 		'property_remote_garage',
 		'property_secure_parking',
@@ -846,6 +855,8 @@ function epl_property_tab_section() {
 			$the_property_feature_list .= $property->get_additional_features_html($additional_feature);
 		}
 	}
+
+	$the_property_feature_list .= apply_filters('epl_the_property_feature_list_after', '' );
 
 	if ( $property->post_type != 'land' || $property->post_type != 'business') { ?>
 		<?php $property_features_title = apply_filters( 'epl_property_sub_title_property_features' , __('Property Features', 'easy-property-listings' ) ); ?>

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -782,8 +782,12 @@ function epl_property_tab_section() {
 	$post_type = $property->post_type;
 	$the_property_feature_list = apply_filters('epl_the_property_feature_list_before', '' );
 
-	if ( 'property' == $post_type || 'rental' == $post_type || 'rural' == $post_type ) {
+	if ( 'property' == $post_type || 'rental' == $post_type ) {
 		$the_property_feature_list .= $property->get_property_category('li');
+	}
+
+	if ( 'rural' == $post_type ) {
+		$the_property_feature_list .= $property->get_property_rural_category('li');
 	}
 
 	if ( 'commercial' == $post_type || 'commercial_land' == $post_type || 'business' == $post_type ) {

--- a/lib/shortcodes/shortcode-listing-auction.php
+++ b/lib/shortcodes/shortcode-listing-auction.php
@@ -68,6 +68,12 @@ function epl_shortcode_listing_auction_callback( $atts ) {
 		'value'		=> 'no',
 	);
 
+	/** only properties which are not auction should be allowed **/
+	$args['meta_query'][] = array(
+		'key'		=> 'property_authority',
+		'value'		=> 'auction',
+	);
+
 	if(!empty($location) ) {
 		if( !is_array( $location ) ) {
 			$location = explode(",", $location);

--- a/readme.txt
+++ b/readme.txt
@@ -394,9 +394,20 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 
 = 3.1.12 April 27, 2017 =
 
-*
-
-
+* New: Filter epl_property_land_area_unit_label for Land Unit Label Filter.
+* New: Filter epl_property_building_area_unit_label for Building Unit Label Filter.
+* New: Filter epl_the_property_feature_list_before before the features list.
+* New: Filter epl_the_property_feature_list_before_common_features before the common features list.
+* New: Filter epl_the_property_feature_list_before_additional_features before the additional features list.
+* New: Filter epl_the_property_feature_list_after for after the output of the features list.
+* Tweak: Property, Rural, Commercial Category output to secondary heading.
+* Tweak: Altered land sqm output to m2.
+* Tweak: Shortcode [listing_auction] now only displays auction listings.
+* Fix: Property Category now outputs to feature list.
+* Fix: Rural Category now outputs to feature list.
+* Fix: Commercial Category now outputs to feature list.
+* Fix: Empty Commercial Features heading no longer outputs heading if values are empty.
+* Fix: Empty Rural Features heading no longer outputs heading if values are empty.
 
 = 3.1.11 April 6, 2017 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Contributors: mervb1
 Donate link: https://easypropertylistings.com.au/support-the-site/
 Tags: real estate, property, listings, CRM, contact management, reports, rental, commercial, business, rural, land, residential, property listings, property management, realtor, broker, contact, crm, australia, wp-property, wp property, wp rentals, wp-realestate, wp real estate, multisite, property, Merv Barrett, real estate connected
 Requires at least: 3.9
-Tested up to: 4.7.3
+Tested up to: 4.7.4
 
 Stable Tag: 3.1.11
 
@@ -391,6 +391,12 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 8. Home open shortcode and Multi Author widget
 
 == Changelog ==
+
+= 3.1.12 April 27, 2017 =
+
+*
+
+
 
 = 3.1.11 April 6, 2017 =
 


### PR DESCRIPTION
* New: Filter epl_property_land_area_unit_label for Land Unit Label Filter.
* New: Filter epl_property_building_area_unit_label for Building Unit Label Filter.
* New: Filter epl_the_property_feature_list_before before the features list.
* New: Filter epl_the_property_feature_list_before_common_features before the common features list.
* New: Filter epl_the_property_feature_list_before_additional_features before the additional features list.
* New: Filter epl_the_property_feature_list_after for after the output of the features list.
* Tweak: Property, Rural, Commercial Category output to secondary heading.
* Tweak: Altered land sqm output to m2.
* Tweak: Shortcode [listing_auction] now only displays auction listings.
* Fix: Property Category now outputs to feature list.
* Fix: Rural Category now outputs to feature list.
* Fix: Commercial Category now outputs to feature list.
* Fix: Empty Commercial Features heading no longer outputs heading if values are empty.
* Fix: Empty Rural Features heading no longer outputs heading if values are empty.