### PR TITLE
Easy Property Listings 3.3.1 Maintenance Release

### DIFF
--- a/languages/easy-property-listings.pot
+++ b/languages/easy-property-listings.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Easy Property Listings 3.3.1\n"
 "Report-Msgid-Bugs-To: http://wordpress.org/support/plugin/easy-property-listings\n"
-"POT-Creation-Date: 2019-05-23 06:57:50+00:00\n"
+"POT-Creation-Date: 2019-05-27 04:41:33+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -3654,7 +3654,7 @@ msgstr ""
 
 #: lib/includes/functions.php:1559
 msgid ""
-"Use the following settings to change how the Dashbord > Property or any "
+"Use the following settings to change how the Dashboard > Property or any "
 "listing of the types you have enabled display."
 msgstr ""
 
@@ -3827,7 +3827,7 @@ msgstr ""
 
 #: lib/includes/functions.php:1814
 msgid ""
-"Additonal settings to control how Easy Property Listings works. For even "
+"Additional settings to control how Easy Property Listings works. For even "
 "more advanced filters and hooks, <a href=\"%s\" target=\"_blank\">visit the "
 "codex</a>."
 msgstr ""

--- a/lib/includes/class-epl-search.php
+++ b/lib/includes/class-epl-search.php
@@ -97,7 +97,7 @@ class EPL_SEARCH {
 		$this->query->is_page 		= false;
 		$this->query->is_single 	= false;
 		$this->query->is_singular 	= false;
-		$this->query->is_epl_search = true;
+		$this->query->is_epl_search	= true;
 		set_query_var('page_id',null);
 
 		//epl_print_r($this->query,true);
@@ -293,10 +293,10 @@ class EPL_SEARCH {
 				$this->form_fields = epl_search_widget_fields_frontend( $this->get_data['post_type'], $this->get_data['property_status'], $this->transaction_type );
 
 			}
-			
+
 		}
 		else {
-			
+
 			$this->form_fields = epl_search_widget_fields_frontend( $this->get_data['post_type'], $this->get_data['property_status'], $this->transaction_type );
 		}
 
@@ -339,7 +339,7 @@ class EPL_SEARCH {
 	function epl_search_query_pre_search() {
 
 		foreach($this->meta_query as $index	=>	&$meta_query) {
-			
+
 			if( !isset($meta_query['key']) )
 				continue;
 
@@ -527,7 +527,7 @@ class EPL_SEARCH {
 				'terms'		=>	$value,
 			);
 		}
-		
+
 		$this->tax_query = apply_filters('epl_preprocess_search_tax_query',$this->tax_query);
 	}
 

--- a/lib/includes/functions.php
+++ b/lib/includes/functions.php
@@ -1811,7 +1811,7 @@ function epl_render_html_fields ( $field = array() , $val = '' ) {
 			'label'		=>	__('Advanced Settings' , 'easy-property-listings' ),
 			'class'		=>	'core',
 			'id'		=>	'advanced',
-			'help'		=>	sprintf( __('Additonal settings to control how Easy Property Listings works. For even more advanced filters and hooks, <a href="%s" target="_blank">visit the codex</a>.' , 'easy-property-listings' ) ,esc_url( 'https://codex.easypropertylistings.com.au/' ) ). '<hr/>',
+			'help'		=>	sprintf( __('Additional settings to control how Easy Property Listings works. For even more advanced filters and hooks, <a href="%s" target="_blank">visit the codex</a>.' , 'easy-property-listings' ) ,esc_url( 'https://codex.easypropertylistings.com.au/' ) ). '<hr/>',
 			'fields'	=>	array(
 				array(
 					'name'		=>	'epl_use_core_css',

--- a/lib/includes/functions.php
+++ b/lib/includes/functions.php
@@ -1556,7 +1556,7 @@ function epl_render_html_fields ( $field = array() , $val = '' ) {
 			'label'		=>	__('Dashboard Listing Columns' , 'easy-property-listings' ),
 			'class'		=>	'core',
 			'id'		=>	'admin_general',
-			'help'		=>	__('Use the following settings to change how the Dashbord > Property or any listing of the types you have enabled display.' , 'easy-property-listings' ) . '<hr/>',
+			'help'		=>	__('Use the following settings to change how the Dashboard > Property or any listing of the types you have enabled display.' , 'easy-property-listings' ) . '<hr/>',
 			'fields'	=>	array(
 
 				array(

--- a/lib/templates/content/shortcode-listing.php
+++ b/lib/templates/content/shortcode-listing.php
@@ -20,8 +20,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( $query_open->have_posts() ) {
 	$attributes['class'] = isset( $attributes['class'] ) ? $attributes['class'] : 'epl-shortcode-listing';
 	?>
-	<div class="loop epl-shortcode">
-		<div class="loop-content <?php echo $attributes['class']; ?> <?php echo epl_template_class( $attributes['template'], 'archive' ); ?>">
+	<div class="loop epl-shortcode epl-clearfix">
+		<div class="loop-content <?php echo $attributes['class']; ?> <?php echo epl_template_class( $attributes['template'], 'archive' ); ?> epl-clearfix">
 			<?php
 			if ( $attributes['tools_top'] == 'on' ) {
 				do_action( 'epl_property_loop_start' );
@@ -36,7 +36,7 @@ if ( $query_open->have_posts() ) {
 			}
 			?>
 		</div>
-		<div class="loop-footer">
+		<div class="loop-footer epl-clearfix">
 				<?php
 					if ( $attributes['pagination'] == 'on' ) {
 						do_action( 'epl_pagination',array( 'query'	=> $query_open ) );

--- a/readme.txt
+++ b/readme.txt
@@ -397,6 +397,7 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 
 * Tweak: Grid CSS tweaked when using Enhanced CSS option with some themes.
 * Tweak: Altered the options to the new [listing_element] shortcode for easier use and documentation.
+* Tweak: Added epl-clearfix to shortcode template to better clear whne using page builder plugins.
 * Fix: Corrected a warning and notice errors when using the new [listing_advanced] shortcode with no options.
 * Fix: Corrected an error when using the new [listing_element] shortcode.
 

--- a/readme.txt
+++ b/readme.txt
@@ -398,6 +398,7 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 * Tweak: Grid CSS tweaked when using Enhanced CSS option with some themes.
 * Tweak: Altered the options to the new [listing_element] shortcode for easier use and documentation.
 * Fix: Corrected a warning and notice errors when using the new [listing_advanced] shortcode with no options.
+* Fix: Corrected an error when using the new [listing_element] shortcode.
 
 = 3.3 May 22, 2019 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -393,13 +393,14 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 
 == Changelog ==
 
-= 3.3.1 May 23, 2019 =
+= 3.3.1 May 27, 2019 =
 
 * Tweak: Grid CSS tweaked when using Enhanced CSS option with some themes.
 * Tweak: Altered the options to the new [listing_element] shortcode for easier use and documentation.
 * Tweak: Added epl-clearfix to shortcode template to better clear whne using page builder plugins.
-* Fix: Corrected a warning and notice errors when using the new [listing_advanced] shortcode with no options.
-* Fix: Corrected an error when using the new [listing_element] shortcode.
+* Fix: Warning and notice errors when using the new [listing_advanced] shortcode with no options.
+* Fix: Error when using the new [listing_element] shortcode.
+* Fix: Search new feature fix corrected when no post type is set.
 
 = 3.3 May 22, 2019 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -397,7 +397,7 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 
 * Tweak: Grid CSS tweaked when using Enhanced CSS option with some themes.
 * Tweak: Altered the options to the new [listing_element] shortcode for easier use and documentation.
-* Tweak: Added epl-clearfix to shortcode template to better clear whne using page builder plugins.
+* Tweak: Added epl-clearfix to shortcode template to better clear when using page builder plugins.
 * Fix: Warning and notice errors when using the new [listing_advanced] shortcode with no options.
 * Fix: Error when using the new [listing_element] shortcode.
 * Fix: Search new feature fix corrected when no post type is set.


### PR DESCRIPTION
* Tweak: Grid CSS tweaked when using Enhanced CSS option with some themes.
* Tweak: Altered the options to the new [listing_element] shortcode for easier use and documentation.
* Tweak: Added epl-clearfix to shortcode template to better clear when using page builder plugins.
* Fix: Warning and notice errors when using the new [listing_advanced] shortcode with no options.
* Fix: Error when using the new [listing_element] shortcode.
* Fix: Search new feature fix corrected when no post type is set.