### PR TITLE
3.4.4 master

### DIFF
--- a/apigen.neon
+++ b/apigen.neon
@@ -21,7 +21,7 @@ charset: [UTF-8]
 main: EPL
 
 # title of generated documentation
-title: Easy Property Listings 3.4.3 Code Reference
+title: Easy Property Listings 3.4.4 Code Reference
 
 # base url used for sitemap (useful for public doc)
 baseUrl: http://docs.easypropertylistings.com.au/

--- a/easy-property-listings.php
+++ b/easy-property-listings.php
@@ -5,7 +5,7 @@
  * Description:  Fast. Flexible. Forward-thinking solution for real estate agents using WordPress. Easy Property Listing is one of the most dynamic and feature rich Real Estate plugin for WordPress available on the market today. Built for scale, contact generation and works with any theme!
  * Author: Merv Barrett
  * Author URI: http://www.realestateconnected.com.au/
- * Version: 3.4.3
+ * Version: 3.4.4
  * Text Domain: easy-property-listings
  * Domain Path: languages
  *
@@ -25,7 +25,7 @@
  * @package EPL
  * @category Core
  * @author Merv Barrett
- * @version 3.4.3
+ * @version 3.4.4
  */
 
 // Exit if accessed directly.
@@ -94,7 +94,7 @@ if ( ! class_exists( 'Easy_Property_Listings' ) ) :
 		public function setup_constants() {
 			// Plugin version.
 			if ( ! defined( 'EPL_PROPERTY_VER' ) ) {
-				define( 'EPL_PROPERTY_VER', '3.4.3' );
+				define( 'EPL_PROPERTY_VER', '3.4.4' );
 			}
 			// Plugin DB version.
 			if ( ! defined( 'EPL_PROPERTY_DB_VER' ) ) {

--- a/languages/easy-property-listings.pot
+++ b/languages/easy-property-listings.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the Easy Property Listings package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Easy Property Listings 3.4.2\n"
+"Project-Id-Version: Easy Property Listings 3.4.4\n"
 "Report-Msgid-Bugs-To: "
 "http://wordpress.org/support/plugin/easy-property-listings\n"
-"POT-Creation-Date: 2019-08-27 04:18:15+00:00\n"
+"POT-Creation-Date: 2019-09-04 07:36:34+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -309,7 +309,7 @@ msgstr ""
 #: lib/includes/admin/contacts/class-epl-contact-reports-table.php:234
 #: lib/includes/class-epl-author-meta.php:262
 #: lib/includes/class-epl-author-meta.php:270 lib/includes/functions.php:2353
-#: lib/includes/template-functions.php:1817
+#: lib/includes/template-functions.php:1812
 #: lib/post-types/post-type-contact.php:36
 #: lib/post-types/post-type-contact.php:37
 msgid "Contact"
@@ -2087,17 +2087,17 @@ msgstr ""
 msgid "These add-ons extend the functionality of Easy Property Listings."
 msgstr ""
 
-#: lib/includes/admin/menus/menu-extensions.php:93
+#: lib/includes/admin/menus/menu-extensions.php:96
 msgid "Extensions Settings"
 msgstr ""
 
-#: lib/includes/admin/menus/menu-extensions.php:94
+#: lib/includes/admin/menus/menu-extensions.php:97
 msgid ""
 "Configure your extension settings here. Visit the main settings page for "
 "more extension settings."
 msgstr ""
 
-#: lib/includes/admin/menus/menu-extensions.php:200
+#: lib/includes/admin/menus/menu-extensions.php:203
 #: lib/includes/admin/menus/menu-general.php:166
 #: lib/includes/admin/menus/menu-licenses.php:184
 msgid "Save Changes"
@@ -2532,7 +2532,7 @@ msgid "Admin Note"
 msgstr ""
 
 #: lib/includes/class-epl-contact.php:712
-#: lib/includes/template-functions.php:2880
+#: lib/includes/template-functions.php:2875
 #: lib/shortcodes/class-epl-listing-elements.php:77
 msgid "Listing"
 msgstr ""
@@ -3425,12 +3425,12 @@ msgstr ""
 msgid "Listing view type"
 msgstr ""
 
-#: lib/includes/functions.php:1535 lib/includes/template-functions.php:1645
+#: lib/includes/functions.php:1535 lib/includes/template-functions.php:1640
 #: lib/widgets/class-epl-widget-recent-property.php:448
 msgid "List"
 msgstr ""
 
-#: lib/includes/functions.php:1536 lib/includes/template-functions.php:1647
+#: lib/includes/functions.php:1536 lib/includes/template-functions.php:1642
 msgid "Grid"
 msgstr ""
 
@@ -4009,118 +4009,118 @@ msgstr ""
 msgid "&laquo; Previous Page"
 msgstr ""
 
-#: lib/includes/template-functions.php:838
-#: lib/includes/template-functions.php:1263
+#: lib/includes/template-functions.php:833
+#: lib/includes/template-functions.php:1258
 #: lib/meta-boxes/meta-box-init.php:1277
 msgid "Plus Outgoings"
 msgstr ""
 
-#: lib/includes/template-functions.php:857
+#: lib/includes/template-functions.php:852
 msgid "Available from"
 msgstr ""
 
-#: lib/includes/template-functions.php:1244
+#: lib/includes/template-functions.php:1239
 msgid "Property Features"
 msgstr ""
 
-#: lib/includes/template-functions.php:1315
+#: lib/includes/template-functions.php:1310
 #: lib/meta-boxes/meta-box-init.php:1322
 msgid "Commercial Features"
 msgstr ""
 
-#: lib/includes/template-functions.php:1361
+#: lib/includes/template-functions.php:1356
 #: lib/meta-boxes/meta-box-init.php:1127
 msgid "Rural Features"
 msgstr ""
 
-#: lib/includes/template-functions.php:1481
+#: lib/includes/template-functions.php:1476
 msgid "Price: High to Low"
 msgstr ""
 
-#: lib/includes/template-functions.php:1489
+#: lib/includes/template-functions.php:1484
 msgid "Price: Low to High"
 msgstr ""
 
-#: lib/includes/template-functions.php:1498
+#: lib/includes/template-functions.php:1493
 msgid "Date: Newest First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1506
+#: lib/includes/template-functions.php:1501
 msgid "Date: Oldest First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1513
+#: lib/includes/template-functions.php:1508
 msgid "Status : Current First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1522
+#: lib/includes/template-functions.php:1517
 msgid "Status : Sold/Leased First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1531
+#: lib/includes/template-functions.php:1526
 msgid " A-Z"
 msgstr ""
 
-#: lib/includes/template-functions.php:1540
+#: lib/includes/template-functions.php:1535
 msgid " Z-A"
 msgstr ""
 
-#: lib/includes/template-functions.php:1672
+#: lib/includes/template-functions.php:1667
 msgid "Sort"
 msgstr ""
 
-#: lib/includes/template-functions.php:1814
+#: lib/includes/template-functions.php:1809
 msgid "About"
 msgstr ""
 
-#: lib/includes/template-functions.php:1815
+#: lib/includes/template-functions.php:1810
 msgid "Bio"
 msgstr ""
 
-#: lib/includes/template-functions.php:1816
+#: lib/includes/template-functions.php:1811
 msgid "Video"
 msgstr ""
 
-#: lib/includes/template-functions.php:2658
+#: lib/includes/template-functions.php:2653
 msgid "There is no excerpt because this is a protected post."
 msgstr ""
 
-#: lib/includes/template-functions.php:2874
+#: lib/includes/template-functions.php:2869
 #. translators: term name.
 msgid "Property in %s"
 msgstr ""
 
-#: lib/includes/template-functions.php:2876
+#: lib/includes/template-functions.php:2871
 msgid "Search Result"
 msgstr ""
 
-#: lib/includes/template-functions.php:2946
+#: lib/includes/template-functions.php:2941
 #: lib/templates/content/shortcode-listing.php:53
 #. translators: title, page number.
 msgid "Nothing found, please check back later."
 msgstr ""
 
-#: lib/includes/template-functions.php:2949
+#: lib/includes/template-functions.php:2944
 msgid "Nothing currently scheduled for inspection, please check back later."
 msgstr ""
 
-#: lib/includes/template-functions.php:2964
+#: lib/includes/template-functions.php:2959
 msgid "Listing not Found"
 msgstr ""
 
-#: lib/includes/template-functions.php:2966
+#: lib/includes/template-functions.php:2961
 msgid "Listing not found, expand your search criteria and try again."
 msgstr ""
 
-#: lib/includes/template-functions.php:3039
+#: lib/includes/template-functions.php:3034
 msgid "Form submitted successfully"
 msgstr ""
 
-#: lib/includes/template-functions.php:3044
+#: lib/includes/template-functions.php:3039
 msgid "Some issues with form submitted"
 msgstr ""
 
-#: lib/includes/template-functions.php:3063
+#: lib/includes/template-functions.php:3058
 msgid "Email is required"
 msgstr ""
 

--- a/lib/includes/admin/menus/menu-extensions.php
+++ b/lib/includes/admin/menus/menu-extensions.php
@@ -34,24 +34,18 @@ if ( isset( $_REQUEST['action'] ) && 'epl_settings' === $_REQUEST['action'] ) {
 			foreach ( $ext_field_groups['fields'] as $ext_field_group ) {
 				foreach ( $ext_field_group['fields'] as $field ) {
 					if ( 'radio' === $field['type'] || 'checkbox' === $field['type'] ) {
-
 						if ( ! isset( $_REQUEST[ $field['name'] ] ) ) {
 							$_REQUEST[ $field['name'] ] = '';
 						} else {
 							if ( is_array( $_REQUEST[ $field['name'] ] ) ) {
-
 								$_REQUEST[ $field['name'] ] = array_map( 'sanitize_text_field', wp_unslash( $_REQUEST[ $field['name'] ] ) );
-
 							} else {
-
 								$_REQUEST[ $field['name'] ] = sanitize_text_field( wp_unslash( $_REQUEST[ $field['name'] ] ) );
 							}
-							
 						}
 					}
 
 					if ( 'text' === $field['type'] ) {
-
 						if ( isset( $_REQUEST[ $field['name'] ] ) && is_array( $_REQUEST[ $field['name'] ] ) ) {
 							array_walk_recursive( wp_unslash( $_REQUEST[ $field['name'] ] ), 'sanitize_text_field' ); //phpcs:ignore
 						}

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -84,7 +84,8 @@ add_action( 'wp', 'epl_create_property_object' );
 /**
  * Selecting Card Display Style
  *
- * @since      1.0
+ * @since 1.0
+ * @since 3.4.4 Removed default template check for single templates as this caused incorrect templates to load in some cases.
  */
 function epl_property_single() {
 	global $epl_settings;
@@ -314,9 +315,10 @@ function epl_hide_listing_statuses() {
  * Allows the use of one function where we can then select a different template
  * when needed
  *
- * @since      1.0
+ * @since 1.0.0
+ * @since 3.4.4 Removed default template check for loop templates as this caused incorrect templates to load in some cases.
  *
- * @param      string $template  The template.
+ * @param string $template  The template.
  */
 function epl_property_blog( $template = '' ) {
 

--- a/readme.txt
+++ b/readme.txt
@@ -393,6 +393,11 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 
 == Changelog ==
 
+= 3.4.4 September 4, 2019 =
+
+* Fix: Checkbox array options not saving correctly in extensions settings.
+* Fix: Removed default template check for loop and single templates as this caused incorrect templates to load in some cases.
+
 = 3.4.3 August 29, 2019 =
 
 * Fix: Displaying of Geo and Unique ID columns in admin.


### PR DESCRIPTION
* Fix: Checkbox array options not saving correctly in extensions settings.
* Fix: Removed default template check for loop and single templates as this caused incorrect templates to load in some cases.