### PR TITLE
3.4.8 master fix address comma

### DIFF
--- a/apigen.neon
+++ b/apigen.neon
@@ -21,7 +21,7 @@ charset: [UTF-8]
 main: EPL
 
 # title of generated documentation
-title: Easy Property Listings 3.4.7 Code Reference
+title: Easy Property Listings 3.4.8 Code Reference
 
 # base url used for sitemap (useful for public doc)
 baseUrl: http://docs.easypropertylistings.com.au/

--- a/easy-property-listings.php
+++ b/easy-property-listings.php
@@ -5,7 +5,7 @@
  * Description:  Fast. Flexible. Forward-thinking solution for real estate agents using WordPress. Easy Property Listing is one of the most dynamic and feature rich Real Estate plugin for WordPress available on the market today. Built for scale, contact generation and works with any theme!
  * Author: Merv Barrett
  * Author URI: http://www.realestateconnected.com.au/
- * Version: 3.4.7
+ * Version: 3.4.8
  * Text Domain: easy-property-listings
  * Domain Path: languages
  *
@@ -25,7 +25,7 @@
  * @package EPL
  * @category Core
  * @author Merv Barrett
- * @version 3.4.7
+ * @version 3.4.8
  */
 
 // Exit if accessed directly.
@@ -94,7 +94,7 @@ if ( ! class_exists( 'Easy_Property_Listings' ) ) :
 		public function setup_constants() {
 			// Plugin version.
 			if ( ! defined( 'EPL_PROPERTY_VER' ) ) {
-				define( 'EPL_PROPERTY_VER', '3.4.7' );
+				define( 'EPL_PROPERTY_VER', '3.4.8' );
 			}
 			// Plugin DB version.
 			if ( ! defined( 'EPL_PROPERTY_DB_VER' ) ) {

--- a/languages/easy-property-listings.pot
+++ b/languages/easy-property-listings.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Easy Property Listings 3.4.8\n"
 "Report-Msgid-Bugs-To: "
 "http://wordpress.org/support/plugin/easy-property-listings\n"
-"POT-Creation-Date: 2019-09-16 07:04:15+00:00\n"
+"POT-Creation-Date: 2019-09-16 07:13:21+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -309,7 +309,7 @@ msgstr ""
 #: lib/includes/admin/contacts/class-epl-contact-reports-table.php:234
 #: lib/includes/class-epl-author-meta.php:262
 #: lib/includes/class-epl-author-meta.php:270 lib/includes/functions.php:2353
-#: lib/includes/template-functions.php:1824
+#: lib/includes/template-functions.php:1827
 #: lib/post-types/post-type-contact.php:36
 #: lib/post-types/post-type-contact.php:37
 msgid "Contact"
@@ -2532,7 +2532,7 @@ msgid "Admin Note"
 msgstr ""
 
 #: lib/includes/class-epl-contact.php:712
-#: lib/includes/template-functions.php:2887
+#: lib/includes/template-functions.php:2890
 #: lib/shortcodes/class-epl-listing-elements.php:77
 msgid "Listing"
 msgstr ""
@@ -2697,9 +2697,9 @@ msgid "Enter valid license key for automatic updates."
 msgstr ""
 
 #: lib/includes/class-epl-property-meta.php:327
-#: lib/includes/class-epl-property-meta.php:703
-#: lib/includes/class-epl-property-meta.php:765
-#: lib/includes/class-epl-property-meta.php:807 lib/includes/functions.php:2538
+#: lib/includes/class-epl-property-meta.php:706
+#: lib/includes/class-epl-property-meta.php:768
+#: lib/includes/class-epl-property-meta.php:810 lib/includes/functions.php:2538
 #: lib/includes/functions.php:2575 lib/widgets/widget-admin-dashboard.php:176
 #: lib/widgets/widget-admin-dashboard.php:225
 msgid "Auction"
@@ -2709,154 +2709,154 @@ msgstr ""
 msgid "now"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:636
-#: lib/includes/class-epl-property-meta.php:638
+#: lib/includes/class-epl-property-meta.php:639
+#: lib/includes/class-epl-property-meta.php:641
 msgid "Inc. GST"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:640
+#: lib/includes/class-epl-property-meta.php:643
 msgid "GST"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:667
-#: lib/includes/class-epl-property-meta.php:767 lib/includes/functions.php:1429
+#: lib/includes/class-epl-property-meta.php:670
+#: lib/includes/class-epl-property-meta.php:770 lib/includes/functions.php:1429
 #: lib/includes/install.php:47
 msgid "POA"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:691
-#: lib/includes/class-epl-property-meta.php:795
+#: lib/includes/class-epl-property-meta.php:694
+#: lib/includes/class-epl-property-meta.php:798
 msgid "TBA"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:705
 #: lib/includes/class-epl-property-meta.php:708
-#: lib/includes/class-epl-property-meta.php:811
-#: lib/includes/class-epl-property-meta.php:817
-#: lib/includes/class-epl-property-meta.php:1002
+#: lib/includes/class-epl-property-meta.php:711
+#: lib/includes/class-epl-property-meta.php:814
+#: lib/includes/class-epl-property-meta.php:820
+#: lib/includes/class-epl-property-meta.php:1005
 #: lib/includes/functions.php:2574
 msgid "For Sale"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:717
-#: lib/includes/class-epl-property-meta.php:719
-#: lib/includes/class-epl-property-meta.php:721
+#: lib/includes/class-epl-property-meta.php:720
+#: lib/includes/class-epl-property-meta.php:722
 #: lib/includes/class-epl-property-meta.php:724
-#: lib/includes/class-epl-property-meta.php:828
+#: lib/includes/class-epl-property-meta.php:727
 #: lib/includes/class-epl-property-meta.php:831
-#: lib/includes/class-epl-property-meta.php:836
-#: lib/includes/class-epl-property-meta.php:854
-#: lib/includes/class-epl-property-meta.php:859
-#: lib/includes/class-epl-property-meta.php:1015
-#: lib/includes/class-epl-property-meta.php:1017
+#: lib/includes/class-epl-property-meta.php:834
+#: lib/includes/class-epl-property-meta.php:839
+#: lib/includes/class-epl-property-meta.php:857
+#: lib/includes/class-epl-property-meta.php:862
+#: lib/includes/class-epl-property-meta.php:1018
+#: lib/includes/class-epl-property-meta.php:1020
 msgid "For Lease"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:800
-#: lib/includes/class-epl-property-meta.php:998 lib/includes/functions.php:749
+#: lib/includes/class-epl-property-meta.php:803
+#: lib/includes/class-epl-property-meta.php:1001 lib/includes/functions.php:749
 msgid "P.A."
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:809
+#: lib/includes/class-epl-property-meta.php:812
 msgid "For Sale and Lease"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1039
+#: lib/includes/class-epl-property-meta.php:1042
 msgid "Built"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1088
+#: lib/includes/class-epl-property-meta.php:1091
 #: lib/meta-boxes/meta-box-init.php:254
 msgid "Bedrooms"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1089
+#: lib/includes/class-epl-property-meta.php:1092
 msgid "bed"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1147
+#: lib/includes/class-epl-property-meta.php:1150
 #: lib/meta-boxes/meta-box-init.php:262 lib/widgets/widget-functions.php:631
 msgid "Bathrooms"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1148
+#: lib/includes/class-epl-property-meta.php:1151
 msgid "bath"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1206
+#: lib/includes/class-epl-property-meta.php:1209
 #: lib/meta-boxes/meta-box-init.php:304 lib/post-types/post-types.php:342
 #: lib/widgets/widget-functions.php:174 lib/widgets/widget-functions.php:650
 msgid "Rooms"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1267
+#: lib/includes/class-epl-property-meta.php:1270
 msgid "Parking Spaces"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1324
+#: lib/includes/class-epl-property-meta.php:1327
 msgid "garage"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1372
+#: lib/includes/class-epl-property-meta.php:1375
 msgid "carport"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1421
+#: lib/includes/class-epl-property-meta.php:1424
 #: lib/meta-boxes/meta-box-init.php:339 lib/widgets/widget-functions.php:819
 msgid "Air Conditioning"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1480
+#: lib/includes/class-epl-property-meta.php:1483
 #: lib/meta-boxes/meta-box-init.php:330 lib/widgets/widget-functions.php:834
 msgid "Pool"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1537
+#: lib/includes/class-epl-property-meta.php:1540
 msgid "Alarm System"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1584
-#: lib/includes/class-epl-property-meta.php:1655
+#: lib/includes/class-epl-property-meta.php:1587
+#: lib/includes/class-epl-property-meta.php:1658
 #: lib/post-types/post-types.php:352
 msgid "m&#178;"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1597
-#: lib/includes/class-epl-property-meta.php:1609
+#: lib/includes/class-epl-property-meta.php:1600
+#: lib/includes/class-epl-property-meta.php:1612
 msgid "Land is"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1668
-#: lib/includes/class-epl-property-meta.php:1680
+#: lib/includes/class-epl-property-meta.php:1671
+#: lib/includes/class-epl-property-meta.php:1683
 msgid "Floor Area is"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1728
+#: lib/includes/class-epl-property-meta.php:1731
 #: lib/meta-boxes/meta-box-init.php:406 lib/meta-boxes/meta-box-init.php:762
 msgid "Energy Rating"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1773
+#: lib/includes/class-epl-property-meta.php:1776
 #: lib/meta-boxes/meta-box-init.php:320
 msgid "New Construction"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1813
+#: lib/includes/class-epl-property-meta.php:1816
 #: lib/meta-boxes/meta-box-init.php:1113
 msgid "Holiday Rental"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1863
+#: lib/includes/class-epl-property-meta.php:1866
 #: lib/meta-boxes/meta-box-init.php:1104
 msgid "Furnished"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1909
+#: lib/includes/class-epl-property-meta.php:1912
 #: lib/meta-boxes/meta-box-init.php:357
 msgid "Pet Friendly"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1955
+#: lib/includes/class-epl-property-meta.php:1958
 #: lib/post-types/post-type-business.php:94
 #: lib/post-types/post-type-commercial-land.php:94
 #: lib/post-types/post-type-commercial.php:94
@@ -3426,12 +3426,12 @@ msgstr ""
 msgid "Listing view type"
 msgstr ""
 
-#: lib/includes/functions.php:1535 lib/includes/template-functions.php:1652
+#: lib/includes/functions.php:1535 lib/includes/template-functions.php:1655
 #: lib/widgets/class-epl-widget-recent-property.php:447
 msgid "List"
 msgstr ""
 
-#: lib/includes/functions.php:1536 lib/includes/template-functions.php:1654
+#: lib/includes/functions.php:1536 lib/includes/template-functions.php:1657
 msgid "Grid"
 msgstr ""
 
@@ -4010,118 +4010,118 @@ msgstr ""
 msgid "&laquo; Previous Page"
 msgstr ""
 
-#: lib/includes/template-functions.php:845
-#: lib/includes/template-functions.php:1270
+#: lib/includes/template-functions.php:848
+#: lib/includes/template-functions.php:1273
 #: lib/meta-boxes/meta-box-init.php:1277
 msgid "Plus Outgoings"
 msgstr ""
 
-#: lib/includes/template-functions.php:864
+#: lib/includes/template-functions.php:867
 msgid "Available from"
 msgstr ""
 
-#: lib/includes/template-functions.php:1251
+#: lib/includes/template-functions.php:1254
 msgid "Property Features"
 msgstr ""
 
-#: lib/includes/template-functions.php:1322
+#: lib/includes/template-functions.php:1325
 #: lib/meta-boxes/meta-box-init.php:1322
 msgid "Commercial Features"
 msgstr ""
 
-#: lib/includes/template-functions.php:1368
+#: lib/includes/template-functions.php:1371
 #: lib/meta-boxes/meta-box-init.php:1127
 msgid "Rural Features"
 msgstr ""
 
-#: lib/includes/template-functions.php:1488
+#: lib/includes/template-functions.php:1491
 msgid "Price: High to Low"
 msgstr ""
 
-#: lib/includes/template-functions.php:1496
+#: lib/includes/template-functions.php:1499
 msgid "Price: Low to High"
 msgstr ""
 
-#: lib/includes/template-functions.php:1505
+#: lib/includes/template-functions.php:1508
 msgid "Date: Newest First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1513
+#: lib/includes/template-functions.php:1516
 msgid "Date: Oldest First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1520
+#: lib/includes/template-functions.php:1523
 msgid "Status : Current First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1529
+#: lib/includes/template-functions.php:1532
 msgid "Status : Sold/Leased First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1538
+#: lib/includes/template-functions.php:1541
 msgid " A-Z"
 msgstr ""
 
-#: lib/includes/template-functions.php:1547
+#: lib/includes/template-functions.php:1550
 msgid " Z-A"
 msgstr ""
 
-#: lib/includes/template-functions.php:1679
+#: lib/includes/template-functions.php:1682
 msgid "Sort"
 msgstr ""
 
-#: lib/includes/template-functions.php:1821
+#: lib/includes/template-functions.php:1824
 msgid "About"
 msgstr ""
 
-#: lib/includes/template-functions.php:1822
+#: lib/includes/template-functions.php:1825
 msgid "Bio"
 msgstr ""
 
-#: lib/includes/template-functions.php:1823
+#: lib/includes/template-functions.php:1826
 msgid "Video"
 msgstr ""
 
-#: lib/includes/template-functions.php:2665
+#: lib/includes/template-functions.php:2668
 msgid "There is no excerpt because this is a protected post."
 msgstr ""
 
-#: lib/includes/template-functions.php:2881
+#: lib/includes/template-functions.php:2884
 #. translators: term name.
 msgid "Property in %s"
 msgstr ""
 
-#: lib/includes/template-functions.php:2883
+#: lib/includes/template-functions.php:2886
 msgid "Search Result"
 msgstr ""
 
-#: lib/includes/template-functions.php:2953
+#: lib/includes/template-functions.php:2956
 #: lib/templates/content/shortcode-listing.php:53
 #. translators: title, page number.
 msgid "Nothing found, please check back later."
 msgstr ""
 
-#: lib/includes/template-functions.php:2956
+#: lib/includes/template-functions.php:2959
 msgid "Nothing currently scheduled for inspection, please check back later."
 msgstr ""
 
-#: lib/includes/template-functions.php:2971
+#: lib/includes/template-functions.php:2974
 msgid "Listing not Found"
 msgstr ""
 
-#: lib/includes/template-functions.php:2973
+#: lib/includes/template-functions.php:2976
 msgid "Listing not found, expand your search criteria and try again."
 msgstr ""
 
-#: lib/includes/template-functions.php:3046
+#: lib/includes/template-functions.php:3049
 msgid "Form submitted successfully"
 msgstr ""
 
-#: lib/includes/template-functions.php:3051
+#: lib/includes/template-functions.php:3054
 msgid "Some issues with form submitted"
 msgstr ""
 
-#: lib/includes/template-functions.php:3070
+#: lib/includes/template-functions.php:3073
 msgid "Email is required"
 msgstr ""
 

--- a/languages/easy-property-listings.pot
+++ b/languages/easy-property-listings.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the Easy Property Listings package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Easy Property Listings 3.4.7\n"
+"Project-Id-Version: Easy Property Listings 3.4.8\n"
 "Report-Msgid-Bugs-To: "
 "http://wordpress.org/support/plugin/easy-property-listings\n"
-"POT-Creation-Date: 2019-09-16 02:39:31+00:00\n"
+"POT-Creation-Date: 2019-09-16 07:04:15+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -309,7 +309,7 @@ msgstr ""
 #: lib/includes/admin/contacts/class-epl-contact-reports-table.php:234
 #: lib/includes/class-epl-author-meta.php:262
 #: lib/includes/class-epl-author-meta.php:270 lib/includes/functions.php:2353
-#: lib/includes/template-functions.php:1812
+#: lib/includes/template-functions.php:1824
 #: lib/post-types/post-type-contact.php:36
 #: lib/post-types/post-type-contact.php:37
 msgid "Contact"
@@ -2532,7 +2532,7 @@ msgid "Admin Note"
 msgstr ""
 
 #: lib/includes/class-epl-contact.php:712
-#: lib/includes/template-functions.php:2875
+#: lib/includes/template-functions.php:2887
 #: lib/shortcodes/class-epl-listing-elements.php:77
 msgid "Listing"
 msgstr ""
@@ -2697,9 +2697,9 @@ msgid "Enter valid license key for automatic updates."
 msgstr ""
 
 #: lib/includes/class-epl-property-meta.php:327
-#: lib/includes/class-epl-property-meta.php:684
-#: lib/includes/class-epl-property-meta.php:746
-#: lib/includes/class-epl-property-meta.php:788 lib/includes/functions.php:2538
+#: lib/includes/class-epl-property-meta.php:703
+#: lib/includes/class-epl-property-meta.php:765
+#: lib/includes/class-epl-property-meta.php:807 lib/includes/functions.php:2538
 #: lib/includes/functions.php:2575 lib/widgets/widget-admin-dashboard.php:176
 #: lib/widgets/widget-admin-dashboard.php:225
 msgid "Auction"
@@ -2709,153 +2709,154 @@ msgstr ""
 msgid "now"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:617
-#: lib/includes/class-epl-property-meta.php:619
+#: lib/includes/class-epl-property-meta.php:636
+#: lib/includes/class-epl-property-meta.php:638
 msgid "Inc. GST"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:621
+#: lib/includes/class-epl-property-meta.php:640
 msgid "GST"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:648
-#: lib/includes/class-epl-property-meta.php:748 lib/includes/functions.php:1429
+#: lib/includes/class-epl-property-meta.php:667
+#: lib/includes/class-epl-property-meta.php:767 lib/includes/functions.php:1429
 #: lib/includes/install.php:47
 msgid "POA"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:672
-#: lib/includes/class-epl-property-meta.php:776
+#: lib/includes/class-epl-property-meta.php:691
+#: lib/includes/class-epl-property-meta.php:795
 msgid "TBA"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:686
-#: lib/includes/class-epl-property-meta.php:689
-#: lib/includes/class-epl-property-meta.php:792
-#: lib/includes/class-epl-property-meta.php:798
-#: lib/includes/class-epl-property-meta.php:983 lib/includes/functions.php:2574
+#: lib/includes/class-epl-property-meta.php:705
+#: lib/includes/class-epl-property-meta.php:708
+#: lib/includes/class-epl-property-meta.php:811
+#: lib/includes/class-epl-property-meta.php:817
+#: lib/includes/class-epl-property-meta.php:1002
+#: lib/includes/functions.php:2574
 msgid "For Sale"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:698
-#: lib/includes/class-epl-property-meta.php:700
-#: lib/includes/class-epl-property-meta.php:702
-#: lib/includes/class-epl-property-meta.php:705
-#: lib/includes/class-epl-property-meta.php:809
-#: lib/includes/class-epl-property-meta.php:812
-#: lib/includes/class-epl-property-meta.php:817
-#: lib/includes/class-epl-property-meta.php:835
-#: lib/includes/class-epl-property-meta.php:840
-#: lib/includes/class-epl-property-meta.php:996
-#: lib/includes/class-epl-property-meta.php:998
+#: lib/includes/class-epl-property-meta.php:717
+#: lib/includes/class-epl-property-meta.php:719
+#: lib/includes/class-epl-property-meta.php:721
+#: lib/includes/class-epl-property-meta.php:724
+#: lib/includes/class-epl-property-meta.php:828
+#: lib/includes/class-epl-property-meta.php:831
+#: lib/includes/class-epl-property-meta.php:836
+#: lib/includes/class-epl-property-meta.php:854
+#: lib/includes/class-epl-property-meta.php:859
+#: lib/includes/class-epl-property-meta.php:1015
+#: lib/includes/class-epl-property-meta.php:1017
 msgid "For Lease"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:781
-#: lib/includes/class-epl-property-meta.php:979 lib/includes/functions.php:749
+#: lib/includes/class-epl-property-meta.php:800
+#: lib/includes/class-epl-property-meta.php:998 lib/includes/functions.php:749
 msgid "P.A."
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:790
+#: lib/includes/class-epl-property-meta.php:809
 msgid "For Sale and Lease"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1020
+#: lib/includes/class-epl-property-meta.php:1039
 msgid "Built"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1069
+#: lib/includes/class-epl-property-meta.php:1088
 #: lib/meta-boxes/meta-box-init.php:254
 msgid "Bedrooms"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1070
+#: lib/includes/class-epl-property-meta.php:1089
 msgid "bed"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1128
+#: lib/includes/class-epl-property-meta.php:1147
 #: lib/meta-boxes/meta-box-init.php:262 lib/widgets/widget-functions.php:631
 msgid "Bathrooms"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1129
+#: lib/includes/class-epl-property-meta.php:1148
 msgid "bath"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1187
+#: lib/includes/class-epl-property-meta.php:1206
 #: lib/meta-boxes/meta-box-init.php:304 lib/post-types/post-types.php:342
 #: lib/widgets/widget-functions.php:174 lib/widgets/widget-functions.php:650
 msgid "Rooms"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1248
+#: lib/includes/class-epl-property-meta.php:1267
 msgid "Parking Spaces"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1305
+#: lib/includes/class-epl-property-meta.php:1324
 msgid "garage"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1353
+#: lib/includes/class-epl-property-meta.php:1372
 msgid "carport"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1402
+#: lib/includes/class-epl-property-meta.php:1421
 #: lib/meta-boxes/meta-box-init.php:339 lib/widgets/widget-functions.php:819
 msgid "Air Conditioning"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1461
+#: lib/includes/class-epl-property-meta.php:1480
 #: lib/meta-boxes/meta-box-init.php:330 lib/widgets/widget-functions.php:834
 msgid "Pool"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1518
+#: lib/includes/class-epl-property-meta.php:1537
 msgid "Alarm System"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1565
-#: lib/includes/class-epl-property-meta.php:1636
+#: lib/includes/class-epl-property-meta.php:1584
+#: lib/includes/class-epl-property-meta.php:1655
 #: lib/post-types/post-types.php:352
 msgid "m&#178;"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1578
-#: lib/includes/class-epl-property-meta.php:1590
+#: lib/includes/class-epl-property-meta.php:1597
+#: lib/includes/class-epl-property-meta.php:1609
 msgid "Land is"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1649
-#: lib/includes/class-epl-property-meta.php:1661
+#: lib/includes/class-epl-property-meta.php:1668
+#: lib/includes/class-epl-property-meta.php:1680
 msgid "Floor Area is"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1709
+#: lib/includes/class-epl-property-meta.php:1728
 #: lib/meta-boxes/meta-box-init.php:406 lib/meta-boxes/meta-box-init.php:762
 msgid "Energy Rating"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1754
+#: lib/includes/class-epl-property-meta.php:1773
 #: lib/meta-boxes/meta-box-init.php:320
 msgid "New Construction"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1794
+#: lib/includes/class-epl-property-meta.php:1813
 #: lib/meta-boxes/meta-box-init.php:1113
 msgid "Holiday Rental"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1844
+#: lib/includes/class-epl-property-meta.php:1863
 #: lib/meta-boxes/meta-box-init.php:1104
 msgid "Furnished"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1890
+#: lib/includes/class-epl-property-meta.php:1909
 #: lib/meta-boxes/meta-box-init.php:357
 msgid "Pet Friendly"
 msgstr ""
 
-#: lib/includes/class-epl-property-meta.php:1936
+#: lib/includes/class-epl-property-meta.php:1955
 #: lib/post-types/post-type-business.php:94
 #: lib/post-types/post-type-commercial-land.php:94
 #: lib/post-types/post-type-commercial.php:94
@@ -3425,12 +3426,12 @@ msgstr ""
 msgid "Listing view type"
 msgstr ""
 
-#: lib/includes/functions.php:1535 lib/includes/template-functions.php:1640
+#: lib/includes/functions.php:1535 lib/includes/template-functions.php:1652
 #: lib/widgets/class-epl-widget-recent-property.php:447
 msgid "List"
 msgstr ""
 
-#: lib/includes/functions.php:1536 lib/includes/template-functions.php:1642
+#: lib/includes/functions.php:1536 lib/includes/template-functions.php:1654
 msgid "Grid"
 msgstr ""
 
@@ -4009,118 +4010,118 @@ msgstr ""
 msgid "&laquo; Previous Page"
 msgstr ""
 
-#: lib/includes/template-functions.php:833
-#: lib/includes/template-functions.php:1258
+#: lib/includes/template-functions.php:845
+#: lib/includes/template-functions.php:1270
 #: lib/meta-boxes/meta-box-init.php:1277
 msgid "Plus Outgoings"
 msgstr ""
 
-#: lib/includes/template-functions.php:852
+#: lib/includes/template-functions.php:864
 msgid "Available from"
 msgstr ""
 
-#: lib/includes/template-functions.php:1239
+#: lib/includes/template-functions.php:1251
 msgid "Property Features"
 msgstr ""
 
-#: lib/includes/template-functions.php:1310
+#: lib/includes/template-functions.php:1322
 #: lib/meta-boxes/meta-box-init.php:1322
 msgid "Commercial Features"
 msgstr ""
 
-#: lib/includes/template-functions.php:1356
+#: lib/includes/template-functions.php:1368
 #: lib/meta-boxes/meta-box-init.php:1127
 msgid "Rural Features"
 msgstr ""
 
-#: lib/includes/template-functions.php:1476
+#: lib/includes/template-functions.php:1488
 msgid "Price: High to Low"
 msgstr ""
 
-#: lib/includes/template-functions.php:1484
+#: lib/includes/template-functions.php:1496
 msgid "Price: Low to High"
 msgstr ""
 
-#: lib/includes/template-functions.php:1493
+#: lib/includes/template-functions.php:1505
 msgid "Date: Newest First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1501
+#: lib/includes/template-functions.php:1513
 msgid "Date: Oldest First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1508
+#: lib/includes/template-functions.php:1520
 msgid "Status : Current First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1517
+#: lib/includes/template-functions.php:1529
 msgid "Status : Sold/Leased First"
 msgstr ""
 
-#: lib/includes/template-functions.php:1526
+#: lib/includes/template-functions.php:1538
 msgid " A-Z"
 msgstr ""
 
-#: lib/includes/template-functions.php:1535
+#: lib/includes/template-functions.php:1547
 msgid " Z-A"
 msgstr ""
 
-#: lib/includes/template-functions.php:1667
+#: lib/includes/template-functions.php:1679
 msgid "Sort"
 msgstr ""
 
-#: lib/includes/template-functions.php:1809
+#: lib/includes/template-functions.php:1821
 msgid "About"
 msgstr ""
 
-#: lib/includes/template-functions.php:1810
+#: lib/includes/template-functions.php:1822
 msgid "Bio"
 msgstr ""
 
-#: lib/includes/template-functions.php:1811
+#: lib/includes/template-functions.php:1823
 msgid "Video"
 msgstr ""
 
-#: lib/includes/template-functions.php:2653
+#: lib/includes/template-functions.php:2665
 msgid "There is no excerpt because this is a protected post."
 msgstr ""
 
-#: lib/includes/template-functions.php:2869
+#: lib/includes/template-functions.php:2881
 #. translators: term name.
 msgid "Property in %s"
 msgstr ""
 
-#: lib/includes/template-functions.php:2871
+#: lib/includes/template-functions.php:2883
 msgid "Search Result"
 msgstr ""
 
-#: lib/includes/template-functions.php:2941
+#: lib/includes/template-functions.php:2953
 #: lib/templates/content/shortcode-listing.php:53
 #. translators: title, page number.
 msgid "Nothing found, please check back later."
 msgstr ""
 
-#: lib/includes/template-functions.php:2944
+#: lib/includes/template-functions.php:2956
 msgid "Nothing currently scheduled for inspection, please check back later."
 msgstr ""
 
-#: lib/includes/template-functions.php:2959
+#: lib/includes/template-functions.php:2971
 msgid "Listing not Found"
 msgstr ""
 
-#: lib/includes/template-functions.php:2961
+#: lib/includes/template-functions.php:2973
 msgid "Listing not found, expand your search criteria and try again."
 msgstr ""
 
-#: lib/includes/template-functions.php:3034
+#: lib/includes/template-functions.php:3046
 msgid "Form submitted successfully"
 msgstr ""
 
-#: lib/includes/template-functions.php:3039
+#: lib/includes/template-functions.php:3051
 msgid "Some issues with form submitted"
 msgstr ""
 
-#: lib/includes/template-functions.php:3058
+#: lib/includes/template-functions.php:3070
 msgid "Email is required"
 msgstr ""
 

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -522,7 +522,7 @@ class EPL_Property_Meta {
 
 		$street = '';
 
-		$lot_number     = $this->get_property_meta( 'property_address_lot_number' );
+		$lot_number = $this->get_property_meta( 'property_address_lot_number' );
 		if ( ! empty( $lot_number ) ) {
 			$street .= $lot_number . ' ';
 		}

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -513,7 +513,7 @@ class EPL_Property_Meta {
 	 * @return string formatted street address
 	 *
 	 * @since 2.0.0
-	 * @since 3.4.8 Corrected spacing if value is present. Implemtend separator with existing filter.
+	 * @since 3.4.8 Corrected spacing if value is present. Implemented separator with existing filter.
 	 */
 	public function get_formatted_property_address( $separator = false, $separator_symbol = ',' ) {
 

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -515,7 +515,7 @@ class EPL_Property_Meta {
 	 * @since 2.0.0
 	 * @since 3.4.8 Corrected spacing if value is present. Implemented separator with existing filter.
 	 */
-	public function get_formatted_property_address( $separator = false, $separator_symbol = ',' ) {
+	public function get_formatted_property_address( $street_separator = true, $separator_symbol = ',' ) {
 
 		$street = '';
 
@@ -538,7 +538,7 @@ class EPL_Property_Meta {
 		if ( ! empty( $street_name ) ) {
 			$street .= $street_name;
 
-			if ( true === $separator ) {
+			if ( true === $street_separator ) {
 				$separator_symbol = apply_filters( 'epl_property_address_separator', ',' );
 				$street           .= $separator_symbol;
 			}

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -515,7 +515,9 @@ class EPL_Property_Meta {
 	 * @since 2.0.0
 	 * @since 3.4.8 Corrected spacing if value is present. Implemtend separator with existing filter.
 	 */
-	public function get_formatted_property_address( $street = '', $separator = true, $separator_symbol = ',' ) {
+	public function get_formatted_property_address( $separator = false, $separator_symbol = ',' ) {
+
+		$street = '';
 
 		$lot_number     = $this->get_property_meta( 'property_address_lot_number' );
 		if ( ! empty( $lot_number ) ) {

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -510,20 +510,37 @@ class EPL_Property_Meta {
 	/**
 	 * Formatted Street level address based on selected display option
 	 *
-	 * @since 2.0
 	 * @return string formatted street address
+	 *
+	 * @since 2.0.0
+	 * @since 3.4.8 Corrected spacing if value is present. Implemtend separator with existing filter.
 	 */
-	public function get_formatted_property_address() {
-		$street     = $this->get_property_meta( 'property_address_lot_number' ) . ' ';
-		$sub_number = $this->get_property_meta( 'property_address_sub_number' );
+	public function get_formatted_property_address( $street = '', $separator = true, $separator_symbol = ',' ) {
 
-		if ( ! empty( $sub_number ) ) {
-			$street .= $this->get_property_meta( 'property_address_sub_number' ) . '/';
+		$lot_number     = $this->get_property_meta( 'property_address_lot_number' );
+		if ( ! empty( $lot_number ) ) {
+			$street .= $lot_number . ' ';
 		}
 
-		$street .= $this->get_property_meta( 'property_address_street_number' ) . ' ';
-		$street .= $this->get_property_meta( 'property_address_street' ) . ' ';
+		$sub_number = $this->get_property_meta( 'property_address_sub_number' );
+		if ( ! empty( $sub_number ) ) {
+			$street .= $sub_number . '/';
+		}
 
+		$street_number = $this->get_property_meta( 'property_address_street_number' );
+		if ( ! empty( $street_number ) ) {
+			$street .= $street_number . ' ';
+		}
+
+		$street_name = $this->get_property_meta( 'property_address_street' );
+		if ( ! empty( $street_name ) ) {
+			$street .= $street_name;
+
+			if ( true === $separator ) {
+				$separator_symbol = apply_filters( 'epl_property_address_separator', ',' );
+				$street           .= $separator_symbol;
+			}
+		}
 		return apply_filters( 'epl_get_formatted_property_address', $street );
 	}
 

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -539,7 +539,7 @@ class EPL_Property_Meta {
 			$street .= $street_name;
 
 			if ( true === $street_separator ) {
-				$separator_symbol = apply_filters( 'epl_property_address_separator', ',' );
+				$separator_symbol = apply_filters( 'epl_property_address_separator', $separator_symbol );
 				$street           .= $separator_symbol;
 			}
 		}

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -510,6 +510,9 @@ class EPL_Property_Meta {
 	/**
 	 * Formatted Street level address based on selected display option
 	 *
+	 * @param bool   $street_separator Output a address separator after the street address.
+	 * @param string $separator_symbol Symbol to use as the address separator, default is a comma.
+	 *
 	 * @return string formatted street address
 	 *
 	 * @since 2.0.0
@@ -540,7 +543,7 @@ class EPL_Property_Meta {
 
 			if ( true === $street_separator ) {
 				$separator_symbol = apply_filters( 'epl_property_address_separator', $separator_symbol );
-				$street           .= $separator_symbol;
+				$street          .= $separator_symbol;
 			}
 		}
 		return apply_filters( 'epl_get_formatted_property_address', $street );

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -620,7 +620,7 @@ function epl_property_get_the_full_address() {
  * @since 3.3.3 Revised.
  * @since 3.4.8 Corrected separator location to appear AFTER the street name.
  */
-function epl_property_the_address( $street_separator = true ) {
+function epl_property_the_address( $street_separator = true, $separator_symbol = ',' ) {
 
 	$epl_property_address_separator        = apply_filters( 'epl_property_address_separator', ',' );
 	$epl_property_address_separator_suburb = apply_filters( 'epl_property_address_separator_suburb', false );
@@ -630,7 +630,7 @@ function epl_property_the_address( $street_separator = true ) {
 
 	?>
 	<?php if ( 'yes' === $property->get_property_meta( 'property_address_display' ) ) { ?>
-		<span class="item-street"><?php echo wp_kses_post( $property->get_formatted_property_address( $street_separator ) ); ?></span>
+		<span class="item-street"><?php echo wp_kses_post( $property->get_formatted_property_address( $street_separator, $separator_symbol ) ); ?></span>
 	<?php } ?>
 
 	<span class="entry-title-sub">
@@ -676,9 +676,9 @@ function epl_property_the_address( $street_separator = true ) {
 	</span>
 	<?php
 }
-add_action( 'epl_property_title', 'epl_property_the_address', 10 , 1 );
-add_action( 'epl_property_tab_address', 'epl_property_the_address', 10 , 1 );
-add_action( 'epl_property_address', 'epl_property_the_address', 10 , 1 );
+add_action( 'epl_property_title', 'epl_property_the_address', 10 , 2 );
+add_action( 'epl_property_tab_address', 'epl_property_the_address', 10 , 2 );
+add_action( 'epl_property_address', 'epl_property_the_address', 10 , 2 );
 
 /**
  * Suburb Name Kept for listing templates extensions which use this function

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -586,9 +586,9 @@ function epl_show_author_widget_by_username( $d_image, $d_icons, $d_bio, $userna
 /**
  * Get the full address
  *
- * @since      1.0
+ * @return string  The full address of the listing.
  *
- * @return     string  ( description_of_the_return_value )
+ * @since 1.0.0
  */
 function epl_property_get_the_full_address() {
 	global $property;
@@ -614,12 +614,15 @@ function epl_property_get_the_full_address() {
  *
  * @since 1.0
  * @since 3.3.3 Revised.
+ * @since 3.4.8 Correcgted separator location to appear AFTER the street name.
  * @hooked epl_property_title
  * @hooked property_tab_address
  */
 function epl_property_the_address() {
 
-	$epl_property_address_separator = apply_filters( 'epl_property_address_separator', ',' );
+	$epl_property_address_separator        = apply_filters( 'epl_property_address_separator', ',' );
+	$epl_property_address_separator_suburb = apply_filters( 'epl_property_address_separator_suburb', false );
+	$epl_property_address_separator_city   = apply_filters( 'epl_property_address_separator_city', false );
 
 	global $property, $epl_settings;
 
@@ -633,17 +636,17 @@ function epl_property_the_address() {
 		if ( 'commercial' === $property->post_type || 'business' === $property->post_type ) {
 			if ( 'yes' === $property->get_property_meta( 'property_com_display_suburb' ) || 'yes' === $property->get_property_meta( 'property_address_display' ) ) {
 			    ?>
-				<span class="item-suburb"><?php echo esc_attr( $property->get_property_meta( 'property_address_suburb' ) ); ?></span><?php //phpcs:disable
-				// Note if the php tag is on the next line it causes a space to appear after the suburb eg name , which is incorrect.
-				if ( strlen( trim( $property->get_property_meta( 'property_address_suburb' ) ) ) ) {
+				<span class="item-suburb"><?php echo esc_attr( $property->get_property_meta( 'property_address_suburb' ) ); ?></span>
+				<?php
+				if ( true === $epl_property_address_separator_suburb && strlen( trim( $property->get_property_meta( 'property_address_suburb' ) ) ) ) {
 					echo '<span class="item-separator">' . esc_attr( $epl_property_address_separator ) . '</span>';
 				}
 			}
 		} else {
 			?>
-			<span class="item-suburb"><?php echo esc_attr( $property->get_property_meta( 'property_address_suburb' ) ); ?></span><?php //phpcs:disable
-			// Note if the php tag is on the next line it causes a space to appear after the suburb eg name , which is incorrect.
-			if ( strlen( trim( $property->get_property_meta( 'property_address_suburb' ) ) ) ) {
+			<span class="item-suburb"><?php echo esc_attr( $property->get_property_meta( 'property_address_suburb' ) ); ?></span>
+			<?php
+			if ( true === $epl_property_address_separator_suburb && strlen( trim( $property->get_property_meta( 'property_address_suburb' ) ) ) ) {
 				echo '<span class="item-separator">' . esc_attr( $epl_property_address_separator ) . '</span>';
 			}
 		}
@@ -653,7 +656,10 @@ function epl_property_the_address() {
 		if ( 'yes' === $property->get_epl_settings( 'epl_enable_city_field' ) ) {
 		?>
 			<span class="item-city"><?php echo esc_attr( $property->get_property_meta( 'property_address_city' ) ); ?></span>
-		<?php
+			<?php
+			if ( true === $epl_property_address_separator_city && strlen( trim( $property->get_property_meta( 'property_address_city' ) ) ) ) {
+				echo '<span class="item-separator">' . esc_attr( $epl_property_address_separator ) . '</span>';
+			}
 		}
 		?>
 		<span class="item-state"><?php echo esc_attr( $property->get_property_meta( 'property_address_state' ) ); ?></span>

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -616,16 +616,19 @@ function epl_property_get_the_full_address() {
  * @hooked epl_property_title
  * @hooked property_tab_address
  *
+ * @param bool   $street_separator Display the street separator.
+ * @param string $separator_symbol Symbol to use as the street separator, default is a comma.
+ *
  * @since 1.0
  * @since 3.3.3 Revised.
- * @since 3.4.8 Corrected separator location to appear AFTER the street name.
+ * @since 3.4.8 Corrected separator location to appear AFTER the street name and options to control display.
  */
 function epl_property_the_address( $street_separator = true, $separator_symbol = ',' ) {
 
 	global $property, $epl_settings;
 
-	if( ! is_bool( $street_separator ) ) {
-		$street_separator  = true;
+	if ( ! is_bool( $street_separator ) ) {
+		$street_separator = true;
 	}
 
 	$epl_property_address_separator        = apply_filters( 'epl_property_address_separator', ',' );
@@ -641,7 +644,7 @@ function epl_property_the_address( $street_separator = true, $separator_symbol =
 		<?php
 		if ( 'commercial' === $property->post_type || 'business' === $property->post_type ) {
 			if ( 'yes' === $property->get_property_meta( 'property_com_display_suburb' ) || 'yes' === $property->get_property_meta( 'property_address_display' ) ) {
-			    ?>
+				?>
 				<span class="item-suburb"><?php echo esc_attr( $property->get_property_meta( 'property_address_suburb' ) ); ?></span>
 				<?php
 				if ( true === $epl_property_address_separator_suburb && strlen( trim( $property->get_property_meta( 'property_address_suburb' ) ) ) ) {
@@ -660,7 +663,7 @@ function epl_property_the_address( $street_separator = true, $separator_symbol =
 
 		<?php
 		if ( 'yes' === $property->get_epl_settings( 'epl_enable_city_field' ) ) {
-		?>
+			?>
 			<span class="item-city"><?php echo esc_attr( $property->get_property_meta( 'property_address_city' ) ); ?></span>
 			<?php
 			if ( true === $epl_property_address_separator_city && strlen( trim( $property->get_property_meta( 'property_address_city' ) ) ) ) {
@@ -672,17 +675,17 @@ function epl_property_the_address( $street_separator = true, $separator_symbol =
 		<span class="item-pcode"><?php echo esc_attr( $property->get_property_meta( 'property_address_postal_code' ) ); ?></span>
 		<?php
 		if ( 'yes' === $property->get_epl_settings( 'epl_enable_country_field' ) ) {
-		?>
+			?>
 			<span class="item-country"><?php echo esc_attr( $property->get_property_meta( 'property_address_country' ) ); ?></span>
-		<?php
+			<?php
 		}
 		?>
 	</span>
 	<?php
 }
-add_action( 'epl_property_title', 'epl_property_the_address', 10 , 2 );
-add_action( 'epl_property_tab_address', 'epl_property_the_address', 10 , 2 );
-add_action( 'epl_property_address', 'epl_property_the_address', 10 , 2 );
+add_action( 'epl_property_title', 'epl_property_the_address', 10, 2 );
+add_action( 'epl_property_tab_address', 'epl_property_the_address', 10, 2 );
+add_action( 'epl_property_address', 'epl_property_the_address', 10, 2 );
 
 /**
  * Suburb Name Kept for listing templates extensions which use this function

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -102,11 +102,12 @@ add_action( 'epl_property_single', 'epl_property_single', 10, 1 );
 /**
  * Featured Image template now loading through filter
  *
- * @since      1.2
- *
  * @param      string  $image_size   The image size.
  * @param      string  $image_class  The image class.
  * @param      boolean $link         The link.
+ *
+ * @since      1.2.0
+ * @since      3.4.8 Corrected missing parameter count to 3.
  */
 function epl_property_featured_image( $image_size = 'index_thumbnail', $image_class = 'index-thumbnail', $link = true ) {
 
@@ -131,8 +132,8 @@ function epl_property_featured_image( $image_size = 'index_thumbnail', $image_cl
 	}
 
 }
-add_action( 'epl_property_featured_image', 'epl_property_featured_image', 10, 2 );
-add_action( 'epl_single_featured_image', 'epl_property_featured_image', 10, 2 );
+add_action( 'epl_property_featured_image', 'epl_property_featured_image', 10, 3 );
+add_action( 'epl_single_featured_image', 'epl_property_featured_image', 10, 3 );
 
 /**
  * Featured Image on archive template now loading through filter
@@ -612,13 +613,14 @@ function epl_property_get_the_full_address() {
 /**
  * Get the full address
  *
- * @since 1.0
- * @since 3.3.3 Revised.
- * @since 3.4.8 Correcgted separator location to appear AFTER the street name.
  * @hooked epl_property_title
  * @hooked property_tab_address
+ *
+ * @since 1.0
+ * @since 3.3.3 Revised.
+ * @since 3.4.8 Corrected separator location to appear AFTER the street name.
  */
-function epl_property_the_address() {
+function epl_property_the_address( $street_separator = true ) {
 
 	$epl_property_address_separator        = apply_filters( 'epl_property_address_separator', ',' );
 	$epl_property_address_separator_suburb = apply_filters( 'epl_property_address_separator_suburb', false );
@@ -628,7 +630,7 @@ function epl_property_the_address() {
 
 	?>
 	<?php if ( 'yes' === $property->get_property_meta( 'property_address_display' ) ) { ?>
-		<span class="item-street"><?php echo wp_kses_post( $property->get_formatted_property_address() ); ?></span>
+		<span class="item-street"><?php echo wp_kses_post( $property->get_formatted_property_address( $street_separator ) ); ?></span>
 	<?php } ?>
 
 	<span class="entry-title-sub">
@@ -674,9 +676,9 @@ function epl_property_the_address() {
 	</span>
 	<?php
 }
-add_action( 'epl_property_title', 'epl_property_the_address' );
-add_action( 'epl_property_tab_address', 'epl_property_the_address' );
-add_action( 'epl_property_address', 'epl_property_the_address' );
+add_action( 'epl_property_title', 'epl_property_the_address', 10 , 1 );
+add_action( 'epl_property_tab_address', 'epl_property_the_address', 10 , 1 );
+add_action( 'epl_property_address', 'epl_property_the_address', 10 , 1 );
 
 /**
  * Suburb Name Kept for listing templates extensions which use this function

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -622,11 +622,15 @@ function epl_property_get_the_full_address() {
  */
 function epl_property_the_address( $street_separator = true, $separator_symbol = ',' ) {
 
+	global $property, $epl_settings;
+
+	if( ! is_bool( $street_separator ) ) {
+		$street_separator  = true;
+	}
+
 	$epl_property_address_separator        = apply_filters( 'epl_property_address_separator', ',' );
 	$epl_property_address_separator_suburb = apply_filters( 'epl_property_address_separator_suburb', false );
 	$epl_property_address_separator_city   = apply_filters( 'epl_property_address_separator_city', false );
-
-	global $property, $epl_settings;
 
 	?>
 	<?php if ( 'yes' === $property->get_property_meta( 'property_address_display' ) ) { ?>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "easy-property-listings",
   "title": "Easy Property Listings",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "homepage": "https://easypropertylistings.com.au/",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -395,7 +395,9 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 
 = 3.4.8 September 16, 2019 =
 
+* Tweak: Added filter to optionally control separator output to appear after suburb with epl_property_address_separator_suburb or after the city with the epl_property_address_separator_city filter.
 * Fix: Correction to address separator placement that appeared after suburb in some cases.
+* Fix: Passing the third link parameter to the feature image through a hook has been corrected.
 
 = 3.4.7 September 16, 2019 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -393,6 +393,10 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 
 == Changelog ==
 
+= 3.4.8 September 16, 2019 =
+
+* Fix: Correction to address separator placement that appeared after suburb in some cases.
+
 = 3.4.7 September 16, 2019 =
 
 * Tweak: Whitelist use tag for SVG usage.


### PR DESCRIPTION
* Tweak: Added filter to optionally control separator output to appear after suburb with epl_property_address_separator_suburb or after the city with the epl_property_address_separator_city filter.
* Fix: Correction to address separator placement that appeared after suburb in some cases.
* Fix: Passing the third link parameter to the feature image through a hook has been corrected.