### PR TITLE
3.4.17 master

### DIFF
--- a/apigen.neon
+++ b/apigen.neon
@@ -21,7 +21,7 @@ charset: [UTF-8]
 main: EPL
 
 # title of generated documentation
-title: Easy Property Listings 3.4.16 Code Reference
+title: Easy Property Listings 3.4.17 Code Reference
 
 # base url used for sitemap (useful for public doc)
 baseUrl: http://docs.easypropertylistings.com.au/

--- a/easy-property-listings.php
+++ b/easy-property-listings.php
@@ -5,7 +5,7 @@
  * Description:  Fast. Flexible. Forward-thinking solution for real estate agents using WordPress. Easy Property Listing is one of the most dynamic and feature rich Real Estate plugin for WordPress available on the market today. Built for scale, contact generation and works with any theme!
  * Author: Merv Barrett
  * Author URI: http://www.realestateconnected.com.au/
- * Version: 3.4.16
+ * Version: 3.4.17
  * Text Domain: easy-property-listings
  * Domain Path: languages
  *
@@ -25,7 +25,7 @@
  * @package EPL
  * @category Core
  * @author Merv Barrett
- * @version 3.4.16
+ * @version 3.4.17
  */
 
 // Exit if accessed directly.
@@ -95,7 +95,7 @@ if ( ! class_exists( 'Easy_Property_Listings' ) ) :
 		public function setup_constants() {
 			// Plugin version.
 			if ( ! defined( 'EPL_PROPERTY_VER' ) ) {
-				define( 'EPL_PROPERTY_VER', '3.4.16' );
+				define( 'EPL_PROPERTY_VER', '3.4.17' );
 			}
 			// Plugin DB version.
 			if ( ! defined( 'EPL_PROPERTY_DB_VER' ) ) {

--- a/languages/easy-property-listings.pot
+++ b/languages/easy-property-listings.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Easy Property Listings package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Easy Property Listings 3.4.16\n"
+"Project-Id-Version: Easy Property Listings 3.4.17\n"
 "Report-Msgid-Bugs-To: "
 "http://wordpress.org/support/plugin/easy-property-listings\n"
 "POT-Creation-Date: 2019-12-02 05:30:54+00:00\n"

--- a/languages/easy-property-listings.pot
+++ b/languages/easy-property-listings.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Easy Property Listings 3.4.16\n"
 "Report-Msgid-Bugs-To: "
 "http://wordpress.org/support/plugin/easy-property-listings\n"
-"POT-Creation-Date: 2019-11-25 08:03:07+00:00\n"
+"POT-Creation-Date: 2019-12-02 05:30:54+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1761,7 +1761,7 @@ msgstr ""
 #: lib/includes/admin/menus/class-epl-welcome.php:560
 #: lib/includes/admin/menus/menu-help.php:174
 #: lib/meta-boxes/meta-box-init.php:220
-#: lib/widgets/class-epl-widget-recent-property.php:551
+#: lib/widgets/class-epl-widget-recent-property.php:541
 msgid "Inspection Times"
 msgstr ""
 
@@ -2532,7 +2532,7 @@ msgid "Admin Note"
 msgstr ""
 
 #: lib/includes/class-epl-contact.php:712
-#: lib/includes/template-functions.php:2933
+#: lib/includes/template-functions.php:2948
 #: lib/shortcodes/class-epl-listing-elements.php:77
 msgid "Listing"
 msgstr ""
@@ -4083,46 +4083,46 @@ msgstr ""
 msgid "Video"
 msgstr ""
 
-#: lib/includes/template-functions.php:2711
+#: lib/includes/template-functions.php:2726
 msgid "There is no excerpt because this is a protected post."
 msgstr ""
 
-#: lib/includes/template-functions.php:2927
+#: lib/includes/template-functions.php:2942
 #. translators: term name.
 msgid "Property in %s"
 msgstr ""
 
-#: lib/includes/template-functions.php:2929
+#: lib/includes/template-functions.php:2944
 msgid "Search Result"
 msgstr ""
 
-#: lib/includes/template-functions.php:2999
+#: lib/includes/template-functions.php:3014
 #: lib/templates/content/shortcode-listing.php:53
 #. translators: title, page number.
 msgid "Nothing found, please check back later."
 msgstr ""
 
-#: lib/includes/template-functions.php:3002
+#: lib/includes/template-functions.php:3017
 msgid "Nothing currently scheduled for inspection, please check back later."
 msgstr ""
 
-#: lib/includes/template-functions.php:3017
+#: lib/includes/template-functions.php:3032
 msgid "Listing not Found"
 msgstr ""
 
-#: lib/includes/template-functions.php:3019
+#: lib/includes/template-functions.php:3034
 msgid "Listing not found, expand your search criteria and try again."
 msgstr ""
 
-#: lib/includes/template-functions.php:3092
+#: lib/includes/template-functions.php:3107
 msgid "Form submitted successfully"
 msgstr ""
 
-#: lib/includes/template-functions.php:3097
+#: lib/includes/template-functions.php:3112
 msgid "Some issues with form submitted"
 msgstr ""
 
-#: lib/includes/template-functions.php:3116
+#: lib/includes/template-functions.php:3131
 msgid "Email is required"
 msgstr ""
 
@@ -5670,12 +5670,12 @@ msgstr ""
 msgid "Street Address"
 msgstr ""
 
-#: lib/widgets/class-epl-widget-recent-property.php:541
-msgid "Read More Button"
+#: lib/widgets/class-epl-widget-recent-property.php:551
+msgid "Inspection Time iCal Link"
 msgstr ""
 
 #: lib/widgets/class-epl-widget-recent-property.php:561
-msgid "Inspection Time iCal Link"
+msgid "Read More Button"
 msgstr ""
 
 #: lib/widgets/class-epl-widget-recent-property.php:565

--- a/lib/assets/assets-svg.php
+++ b/lib/assets/assets-svg.php
@@ -295,6 +295,7 @@ add_filter( 'safe_style_css', 'epl_whitelist_display_attr' );
  * Svg Allowed tags
  *
  * @since  3.4
+ * @since  3.4.17	Allows circle tag.
  */
 function epl_get_svg_allowed_tags() {
 
@@ -356,6 +357,15 @@ function epl_get_svg_allowed_tags() {
 		'use'     => array(
 			'xlink:href' => true,
 		),
+		'circle'    => array(
+			'style'  => true,
+			'class'  => true,
+			'id'     => true,
+			'cx'     => true,
+			'cy'     => true,
+			'r'      => true
+		)
+
 	);
 	return apply_filters( 'epl_svg_allowed_tags', $tags );
 }

--- a/lib/includes/class-epl-metabox.php
+++ b/lib/includes/class-epl-metabox.php
@@ -296,6 +296,7 @@ class EPL_METABOX {
 	 * @param int $post_ID The post ID.
 	 *
 	 * @return int
+	 * @since 3.4.17	Fixed issue : empty values not getting saved for decimals & numbers
 	 */
 	public function save_meta_box( $post_ID ) {
 
@@ -366,7 +367,7 @@ class EPL_METABOX {
 
 												// Validate numeric data.
 
-												if ( ! is_numeric( $_POST[ $field['name'] ] ) ) {
+												if ( ! is_numeric( $_POST[ $field['name'] ] ) && ! empty( $_POST[ $field['name'] ] ) ) {
 													continue;
 												}
 											} elseif ( in_array( $field['type'], array( 'textarea' ), true ) ) {

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -2330,6 +2330,21 @@ function epl_get_shortcode_list() {
 }
 
 /**
+ * Wrapper for wp_doing_ajax with fallback for lower WP versions
+ *
+ * @return     bool  True if its an ajax request
+ * @since      3.4.17
+ */
+function epl_wp_doing_ajax() {
+
+	if( function_exists( 'wp_doing_ajax' ) ) {
+		return wp_doing_ajax();
+	} else {
+		return apply_filters( 'wp_doing_ajax', defined( 'DOING_AJAX' ) && DOING_AJAX );
+	}
+}
+
+/**
  * Pagination fix for home
  *
  * @param      array $query  The query.
@@ -2350,7 +2365,7 @@ function epl_home_pagination_fix( $query ) {
 	$shortcodes = epl_get_shortcode_list();
 
 	if ( $query->get( 'is_epl_shortcode' ) &&
-		in_array( $query->get( 'epl_shortcode_name' ), $shortcodes, true ) && ! wp_doing_ajax() ) {
+		in_array( $query->get( 'epl_shortcode_name' ), $shortcodes, true ) && ! epl_wp_doing_ajax() ) {
 
 		if ( isset( $_GET['pagination_id'] ) && $_GET['pagination_id'] === $query->get( 'instance_id' ) ) {
 			$query->set( 'paged', $query->get( 'paged' ) );

--- a/lib/meta-boxes/meta-boxes.php
+++ b/lib/meta-boxes/meta-boxes.php
@@ -158,6 +158,7 @@ function epl_meta_box_inner_custom_box( $post, $args ) {
  *
  * @return mixed
  * @since 1.0
+ * @since 3.4.17	Fixed issue : empty values not getting saved for decimals & numbers
  */
 function epl_save_meta_boxes( $post_ID ) {
 
@@ -234,7 +235,7 @@ function epl_save_meta_boxes( $post_ID ) {
 											case 'number':
 											case 'decimal':
 												/** Validate numeric data */
-												if ( ! is_numeric( $_POST[ $field['name'] ] ) ) {
+												if ( ! is_numeric( $_POST[ $field['name'] ] ) && ! empty( $_POST[ $field['name'] ] ) ) {
 													continue 2;
 												}
 

--- a/lib/widgets/class-epl-widget-recent-property.php
+++ b/lib/widgets/class-epl-widget-recent-property.php
@@ -532,16 +532,6 @@ class EPL_Widget_Recent_Property extends WP_Widget {
 		</p>
 
 		<p>
-			<input type="checkbox" id="<?php echo $this->get_field_id( 'd_more' ); ?>" name="<?php echo $this->get_field_name( 'd_more' ); ?>"
-												<?php
-												if ( $instance['d_more'] ) {
-													echo 'checked="checked"';}
-												?>
-			/>
-			<label for="<?php echo $this->get_field_id( 'd_more' ); ?>"><?php esc_html_e( 'Read More Button', 'easy-property-listings' ); ?></label>
-		</p>
-
-		<p>
 			<input type="checkbox" id="<?php echo $this->get_field_id( 'd_inspection_time' ); ?>" name="<?php echo $this->get_field_name( 'd_inspection_time' ); ?>"
 												<?php
 												if ( $instance['d_inspection_time'] ) {
@@ -559,6 +549,16 @@ class EPL_Widget_Recent_Property extends WP_Widget {
 												?>
 			/>
 			<label for="<?php echo $this->get_field_id( 'd_ical_link' ); ?>"><?php esc_html_e( 'Inspection Time iCal Link', 'easy-property-listings' ); ?></label>
+		</p>
+
+		<p>
+			<input type="checkbox" id="<?php echo $this->get_field_id( 'd_more' ); ?>" name="<?php echo $this->get_field_name( 'd_more' ); ?>"
+												<?php
+												if ( $instance['d_more'] ) {
+													echo 'checked="checked"';}
+												?>
+			/>
+			<label for="<?php echo $this->get_field_id( 'd_more' ); ?>"><?php esc_html_e( 'Read More Button', 'easy-property-listings' ); ?></label>
 		</p>
 
 		<p>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "easy-property-listings",
   "title": "Easy Property Listings",
-  "version": "3.4.16",
+  "version": "3.4.17",
   "homepage": "https://easypropertylistings.com.au/",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -397,6 +397,13 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 
 == Changelog ==
 
+= 3.4.17 December 2, 2019 =
+
+* Tweak: Moved Readme widget option to appear before the Read me label.
+* Tweak: Wrapper for wp_doing_ajax with fallback for 3.7 versions of WordPress or lower.
+* Fix: SVG filtering now allows circle tag correcting issue with LinkedIn icon missing a dot.
+* Fix: Empty values not getting saved for decimals and numbers.
+
 = 3.4.16 November 25, 2019 =
 
 * Fix: Added check for post type in epl_admin_posts_filter to avoid conflict with other plugins like ninja forms.


### PR DESCRIPTION
* Tweak: Moved Readme widget option to appear before the Read me label.
* Tweak: Wrapper for wp_doing_ajax with fallback for 3.7 versions of WordPress or lower.
* Fix: SVG filtering now allows circle tag correcting issue with LinkedIn icon missing a dot.
* Fix: Empty values not getting saved for decimals and numbers.