### PR TITLE
3.4.27 master

### DIFF
--- a/lib/assets/css/style-admin.css
+++ b/lib/assets/css/style-admin.css
@@ -904,6 +904,9 @@ h3.epl-welcome-sub-heading {
 	color: #fff;
 	background: #aaa;
 }
+.epl-notes-grav + .dashboard-comment-wrap {
+    padding-left: 63px;
+}
 .epl-notes-label {
 	display: block;
 	text-align: center;

--- a/lib/assets/css/style-enhanced.css
+++ b/lib/assets/css/style-enhanced.css
@@ -38,6 +38,9 @@
 .epl-listing-grid-view-forced .epl-list-hidden {
 	display: block;
 }
+.epl-grid-hidden {
+	display: block;
+}
 .epl-listing-grid-view .epl-grid-hidden,
 .epl-listing-grid-view-forced .epl-grid-hidden {
 	display: none;

--- a/lib/compatibility/functions-compat.php
+++ b/lib/compatibility/functions-compat.php
@@ -448,3 +448,38 @@ function epl_property_author_card( $display, $image, $title, $icons ) {
 		<?php
 	}
 }
+
+/**
+ * Modify the Excerpt length on archive pages
+ *
+ * @param int $length Excerpt word length.
+ *
+ * @return int
+ * @since 1.0.0
+ * @since 3.4.27 Depreciated function and deactivated filter.
+ */
+function epl_excerpt_length( $length ) {
+	global $post;
+	if ( 'property' === $post->post_type ) {
+		return 16;
+	} elseif ( 'rental' === $post->post_type ) {
+		return 16;
+	} elseif ( 'commercial' === $post->post_type ) {
+		return 16;
+	} elseif ( 'commercial_land' === $post->post_type ) {
+		return 16;
+	} elseif ( 'business' === $post->post_type ) {
+		return 16;
+	} elseif ( 'rural' === $post->post_type ) {
+		return 16;
+	} elseif ( 'land' === $post->post_type ) {
+		return 16;
+	} elseif ( 'suburb' === $post->post_type ) {
+		return 39;
+	} else {
+		return 55;
+	}
+}
+/**
+ * Filter Removed. add_filter( 'excerpt_length', 'epl_excerpt_length', 999 ); Removed due to fix.
+ */

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -205,7 +205,7 @@ class EPL_Property_Meta {
 
 								$href = get_bloginfo( 'url' ) . '?epl_cal_dl=1&cal=ical&dt=' . base64_encode( htmlspecialchars( $element ) ) . '&propid=' . $this->post->ID;
 
-								$href = apply_filters( 'epl_inpsection_link', $href );
+								$href = apply_filters( 'epl_inspection_link', $href );
 
 								$element_formatted = apply_filters( 'epl_inspection_format', $element );
 

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -2075,10 +2075,33 @@ class EPL_Property_Meta {
 		}
 	}
 
+
+
 	/**
 	 * Get Additional Commercial Features by meta key
 	 *
-	 * @since 2.0
+	 * @since 2.0.0
+	 * @since 3.4.27
+	 * @param string $metakey Meta key name.
+	 * @return mixed Value formatted and wrapped in div with title
+	 */
+	public function get_additional_commercial_features_html( $metakey ) {
+		$metavalue = $this->get_property_meta( $metakey );
+		if ( isset( $metavalue ) && ! empty( $metavalue ) ) {
+			$return = '<div class="' . $this->get_class_from_metakey( $metakey, $search = 'property_com_' ) . '">
+						<h6>' . $this->get_label_from_metakey( $metakey, 'property_com_' ) . '</h6>' .
+			          '<p>' . $metavalue . '</p>' .
+			          '</div>';
+			return apply_filters( 'epl_get_additional_commercial_features_html', $return );
+		}
+	}
+
+	/**
+	 * Get Additional Commercial Features by meta key.
+	 *
+	 * Spelling error in this function. Retained to prevent issues.
+	 *
+	 * @since 2.0.0
 	 * @param string $metakey Meta key name.
 	 * @return mixed Value formatted and wrapped in div with title
 	 */
@@ -2087,8 +2110,8 @@ class EPL_Property_Meta {
 		if ( isset( $metavalue ) && ! empty( $metavalue ) ) {
 			$return = '<div class="' . $this->get_class_from_metakey( $metakey, $search = 'property_com_' ) . '">
 						<h6>' . $this->get_label_from_metakey( $metakey, 'property_com_' ) . '</h6>' .
-						'<p>' . $metavalue . '</p>' .
-					'</div>';
+			          '<p>' . $metavalue . '</p>' .
+			          '</div>';
 			return apply_filters( 'epl_get_additional_commerical_features_html', $return );
 		}
 	}

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -178,7 +178,7 @@ class EPL_Property_Meta {
 							$inspectarray[ strtotime( $endtime ) ] = $item;
 						}
 					} else {
-						$not_date[ $num ] = $num;
+						$not_date[ $num ]     = $num;
 						$inspectarray[ $num ] = $item;
 					}
 				}
@@ -192,14 +192,14 @@ class EPL_Property_Meta {
 					// Unordered list for multiple inspection times.
 					foreach ( $inspectarray as $key => &$element ) {
 
-						$return           .= "<li class='home-open-date epl-no-inspection-date'>";
+						$return .= "<li class='home-open-date epl-no-inspection-date'>";
 
 						if ( ! empty( $element ) ) {
 
-							if( in_array( $key, $not_date ) ) {
+							if ( in_array( $key, $not_date ) ) {
 
 								// handle inspections that are not date.
-								$return 	.= $element;
+								$return .= $element;
 
 							} else {
 
@@ -768,7 +768,7 @@ class EPL_Property_Meta {
 	 * Get Price
 	 *
 	 * @since 2.0
-	 * @since 3.4.27	Fixed rent period translation.
+	 * @since 3.4.27    Fixed rent period translation.
 	 * @return string
 	 */
 	public function get_price() {
@@ -806,9 +806,9 @@ class EPL_Property_Meta {
 				$price .= '<span class="page-price" style="margin-right:0;">' . $this->get_property_rent() . '</span>';
 				if ( empty( $prop_rent_view ) ) {
 					$rent_period_value = $this->get_property_meta( 'property_rent_period' );
-					$rent_options = epl_get_property_rent_period_opts();
+					$rent_options      = epl_get_property_rent_period_opts();
 					$rent_period_label = isset( $rent_options[ $rent_period_value ] ) ? $rent_options[ $rent_period_value ] : ucfirst( $rent_period_value );
-					$price .= '<span class="rent-period">' . $epl_property_price_rent_separator . '' . $rent_period_label . '</span>';
+					$price            .= '<span class="rent-period">' . $epl_property_price_rent_separator . '' . $rent_period_label . '</span>';
 				}
 				$price    .= '</span>';
 				$prop_bond = $this->get_property_bond();
@@ -2090,8 +2090,8 @@ class EPL_Property_Meta {
 		if ( isset( $metavalue ) && ! empty( $metavalue ) ) {
 			$return = '<div class="' . $this->get_class_from_metakey( $metakey, $search = 'property_com_' ) . '">
 						<h6>' . $this->get_label_from_metakey( $metakey, 'property_com_' ) . '</h6>' .
-			          '<p>' . $metavalue . '</p>' .
-			          '</div>';
+					  '<p>' . $metavalue . '</p>' .
+					  '</div>';
 			return apply_filters( 'epl_get_additional_commercial_features_html', $return );
 		}
 	}
@@ -2110,8 +2110,8 @@ class EPL_Property_Meta {
 		if ( isset( $metavalue ) && ! empty( $metavalue ) ) {
 			$return = '<div class="' . $this->get_class_from_metakey( $metakey, $search = 'property_com_' ) . '">
 						<h6>' . $this->get_label_from_metakey( $metakey, 'property_com_' ) . '</h6>' .
-			          '<p>' . $metavalue . '</p>' .
-			          '</div>';
+					  '<p>' . $metavalue . '</p>' .
+					  '</div>';
 			return apply_filters( 'epl_get_additional_commerical_features_html', $return );
 		}
 	}

--- a/lib/includes/functions.php
+++ b/lib/includes/functions.php
@@ -389,8 +389,9 @@ function epl_the_address( $before = '', $after = '', $country = false, $echo = t
  * @param  bool  $country  Return country with true, default false.
  * @return string
  * @since 3.3
+ * @since 3.4.27	Added support for prefix.
  */
-function epl_get_the_address( $address_args = array(), $sep = array(), $country = false ) {
+function epl_get_the_address( $address_args = array(), $sep = array(), $country = false, $prefix = array() ) {
 
 	$address = '';
 
@@ -406,8 +407,22 @@ function epl_get_the_address( $address_args = array(), $sep = array(), $country 
 		'country'       => ' ',
 	);
 
+	$prefix_defaults = array(
+		'sub_number'    => '',
+		'lot_number'    => '',
+		'street_number' => '',
+		'street'        => '',
+		'suburb'        => '',
+		'city'          => '',
+		'state'         => '',
+		'postal_code'   => '',
+		'country'       => ''
+	);
+
 	// override default separators for address components.
 	$seps = array_merge( $address_defaults, $sep );
+
+	$prefix = array_merge( $prefix_defaults, $prefix );
 
 	// Output the full address based on user selection.
 	if ( empty( $address_args ) ) {
@@ -430,7 +445,7 @@ function epl_get_the_address( $address_args = array(), $sep = array(), $country 
 			$value = get_property_meta( 'property_address_' . $arg );
 
 			if ( ! empty( $value ) ) {
-				$address .= get_property_meta( 'property_address_' . $arg ) . $seps[ $arg ];
+				$address .= $prefix[ $args ].get_property_meta( 'property_address_' . $arg ) . $seps[ $arg ];
 			}
 		}
 	}

--- a/lib/includes/functions.php
+++ b/lib/includes/functions.php
@@ -943,10 +943,10 @@ function epl_feedsync_format_strip_currency( $value ) {
  * Processing Function for WP All Import and FeedSync
  * [epl_feedsync_switch_date_time({firstDate[1]},"Australia/Perth","Australia/Sydney")]
  *
- * @param bool   $date_time Swtich date time.
+ * @param bool   $date_time     Switch date time.
  * @param string $old_time_zone Old Timezone.
- * @param string $new_timezone New timezone.
- * @param string $format Date format.
+ * @param string $new_timezone  New timezone.
+ * @param string $format        Date format.
  *
  * @return integer
  * @throws exception Exception.
@@ -1808,7 +1808,7 @@ function epl_get_admin_option_fields() {
 			'label'  => __( 'Currency', 'easy-property-listings' ),
 			'class'  => 'core',
 			'id'     => 'currency',
-			// translators: currency artice link.
+			// Translators: Currency article link.
 			'help'   => sprintf( __( 'Select your default currency. If you can not find the currency you are looking for, you can add additional currencies with a filter, <a href="%s" target="_blank">visit the codex to see how</a>.', 'easy-property-listings' ), esc_url( 'https://codex.easypropertylistings.com.au/article/153-eplgetcurrencies' ) ) . '<hr/>',
 			'fields' => array(
 				array(

--- a/lib/includes/functions.php
+++ b/lib/includes/functions.php
@@ -384,12 +384,14 @@ function epl_the_address( $before = '', $after = '', $country = false, $echo = t
 /**
  * Retrieve address based on user display selection.
  *
- * @param  array $address_args address components.
- * @param  array $sep override default separators for each address components here.
- * @param  bool  $country  Return country with true, default false.
+ * @param array $address_args Address components.
+ * @param array $sep          Override default separators for each address components here.
+ * @param bool  $country      Return country with true, default false.
+ * @param array $prefix       Customise the prefix for each address component.
+ *
  * @return string
  * @since 3.3
- * @since 3.4.27	Added support for prefix.
+ * @since 3.4.27    Added support for prefix.
  */
 function epl_get_the_address( $address_args = array(), $sep = array(), $country = false, $prefix = array() ) {
 
@@ -419,7 +421,7 @@ function epl_get_the_address( $address_args = array(), $sep = array(), $country 
 		'country'       => ''
 	);
 
-	// override default separators for address components.
+	// Override default separators for address components.
 	$seps = array_merge( $address_defaults, $sep );
 
 	$prefix = array_merge( $prefix_defaults, $prefix );

--- a/lib/includes/options-front-end.php
+++ b/lib/includes/options-front-end.php
@@ -15,38 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Modify the Excerpt length on archive pages
- *
- * @param int $length Excerpt word length.
- *
- * @return int
- * @since 1.0
- */
-function epl_excerpt_length( $length ) {
-	global $post;
-	if ( 'property' === $post->post_type ) {
-		return 16;
-	} elseif ( 'rental' === $post->post_type ) {
-		return 16;
-	} elseif ( 'commercial' === $post->post_type ) {
-		return 16;
-	} elseif ( 'commercial_land' === $post->post_type ) {
-		return 16;
-	} elseif ( 'business' === $post->post_type ) {
-		return 16;
-	} elseif ( 'rural' === $post->post_type ) {
-		return 16;
-	} elseif ( 'land' === $post->post_type ) {
-		return 16;
-	} elseif ( 'suburb' === $post->post_type ) {
-		return 39;
-	} else {
-		return 55;
-	}
-}
-add_filter( 'excerpt_length', 'epl_excerpt_length', 999 );
-
-/**
  * Modify the Read More Link of archive pages which can be styled with
  * CSS using the epl-more-link selector
  *

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -2314,7 +2314,7 @@ function epl_get_active_theme() {
 
 	} else {
 		// older versions.
-		$active_theme = get_current_theme(); //phpcs:ignore
+		$active_theme = wp_get_theme(); //phpcs:ignore
 	}
 	$active_theme = str_replace( ' ', '', strtolower( $active_theme ) );
 	return apply_filters( 'epl_active_theme', $active_theme );
@@ -3257,9 +3257,10 @@ function epl_get_post_id_from_unique_id( $unique_id = '' ) {
 /**
  * Renders stickers, based on meta values, an alternative to epl_price_stickers.
  *
- * @param      array $options   The options
- * @param      array $stickers  The stickers
- * @since      3.4.27
+ * @param array $options  The options.
+ * @param array $stickers The stickers.
+ *
+ * @since 3.4.27
  */
 function epl_stickers( $options = array(), $stickers = array() ) {
 
@@ -3289,12 +3290,12 @@ function epl_stickers( $options = array(), $stickers = array() ) {
 	$options = apply_filters( 'epl_stickers_options', $options );
 
 	if ( $options['wrap'] ) {
-		echo '<' . $options['wrapper_tag'] . ' class="' . $options['wrap_class'] . '">';
+		echo '<' . esc_attr( $options['wrapper_tag'] ) . ' class="' . esc_attr( $options['wrap_class'] ) . '">';
 	}
 
 	foreach ( $stickers as $key => $sticker ) {
 
-		if ( $sticker_counts == $default_options['max_stickers'] ) {
+		if ( $sticker_counts === $default_options['max_stickers'] ) {
 			break;
 		}
 		?>
@@ -3308,13 +3309,12 @@ function epl_stickers( $options = array(), $stickers = array() ) {
 				wp_kses_post( $sticker['after'] ) : '';
 			?>
 		</<?php echo esc_attr( $options['sticker_tag'] ); ?>> 
-					 <?php
-
-						$sticker_counts++;
+			<?php
+				$sticker_counts++;
 	}
 
 	if ( $options['wrap'] ) {
-		echo '</' . $options['wrapper_tag'] . '>';
+		echo '</' . esc_attr( $options['wrapper_tag'] ) . '>';
 	}
 
 }

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -3477,7 +3477,7 @@ function epl_get_stickers_array() {
 
 					foreach ( $conditions as $condition_key => $condition_condition ) {
 
-						if ( $compare === '=' ) {
+						if ( '=' === $compare ) {
 
 							if ( is_array( $condition_condition ) ) {
 								if ( ! in_array( get_property_meta( $condition_key ), $condition_condition ) ) {

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -3439,7 +3439,7 @@ function epl_get_stickers_array() {
 
 		if ( ! empty( $sticker ) && is_array( $sticker ) ) {
 
-			if ( ! in_array( get_post_type(), $sticker['type'] ) ) {
+			if ( ! in_array( get_post_type(), $sticker['type'], true ) ) {
 				continue;
 			}
 

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -77,6 +77,8 @@ function epl_create_property_object() {
 			$epl_author_secondary = new EPL_Author_meta( $ID );
 		}
 	}
+
+	add_filter( 'excerpt_length', 'epl_archive_custom_excerpt_length', 999 );
 }
 
 add_action( 'wp', 'epl_create_property_object' );
@@ -139,12 +141,13 @@ add_action( 'epl_single_featured_image', 'epl_property_featured_image', 10, 3 );
  * Featured Image on archive template now loading through filter
  *
  * @since      2.2
+ * @since 		3.4.27 additional param to disable / enable stickers
  *
  * @param      string  $image_size   The image size.
  * @param      string  $image_class  The image class.
  * @param      boolean $link         The link.
  */
-function epl_property_archive_featured_image( $image_size = 'epl-image-medium-crop', $image_class = 'teaser-left-thumb', $link = true ) {
+function epl_property_archive_featured_image( $image_size = 'epl-image-medium-crop', $image_class = 'teaser-left-thumb', $link = true, $stickers = true ) {
 
 	if ( empty( $image_size ) ) {
 		$image_size = 'epl-image-medium-crop';
@@ -162,9 +165,11 @@ function epl_property_archive_featured_image( $image_size = 'epl-image-medium-cr
 				<a href="<?php the_permalink(); ?>">
 			<?php } ?>
 					<div class="epl-blog-image">
+						<?php if( $stickers ) :  ?>
 						<div class="epl-stickers-wrapper">
 							<?php echo wp_kses_post( epl_get_price_sticker() ); ?>
 						</div>
+						<?php endif; ?>
 						<?php the_post_thumbnail( $image_size, array( 'class' => $image_class ) ); ?>
 					</div>
 			<?php if ( true === $link ) { ?>
@@ -283,21 +288,18 @@ function epl_get_template_part( $template, $arguments = array() ) {
  * Modify the Excerpt length on Archive pages
  *
  * @since 1.0
+ * @since 3.4.27 Alter length only for EPL posts.
  * @param string $length Excerpt word length.
  * @return int|string
  */
 function epl_archive_custom_excerpt_length( $length ) {
-	global $epl_settings;
-	$excerpt = '';
-	if ( ! empty( $epl_settings ) && isset( $epl_settings['display_excerpt_length'] ) ) {
-		$excerpt = $epl_settings['display_excerpt_length'];
-	}
-	if ( ! empty( $excerpt ) ) {
-		return 22;
-	} else {
-		return $excerpt;
-	}
+
+	if( !is_epl_post() ) 
+		return $length;
+
+	return epl_get_option( 'display_excerpt_length', 22 );
 }
+
 
 /**
  * Filter which listing status should not be displayed
@@ -329,7 +331,6 @@ function epl_property_blog( $template = '' ) {
 	}
 	$template = str_replace( '_', '-', $template );
 
-	add_filter( 'excerpt_length', 'epl_archive_custom_excerpt_length', 999 );
 	global $epl_settings,$property;
 
 	if ( is_null( $property ) ) {
@@ -1033,6 +1034,8 @@ function epl_get_video_html( $property_video_url = '', $width = 600 ) {
 	/** Remove related videos from youtube */
 	if ( 'youtube' === epl_get_video_host( $property_video_url ) ) {
 
+		$property_video_url = epl_convert_youtube_embed_url( $property_video_url );
+
 		if ( strpos( $property_video_url, '?' ) > 0 ) {
 			$property_video_url .= '&rel=0';
 		} else {
@@ -1050,6 +1053,28 @@ function epl_get_video_html( $property_video_url = '', $width = 600 ) {
 		$video_html     .= '</div>';
 		return $video_html;
 	}
+}
+
+/**
+ * Convert embed URLs to non embed URLs for WP Oembed compatiblity.
+ *
+ * @param      string  $url    The url
+ *
+ * @return     string 	converted URL
+ * @since 	   3.4.27	
+ */
+function epl_convert_youtube_embed_url( $url ) {
+
+	if ( strpos( $url, 'embed' ) > 0 ) {
+
+		$video_id = epl_get_youtube_id_from_url( $url );
+
+		if( !empty( $video_id) ) {
+			$url = 'https://www.youtube.com/watch?v='.$video_id;
+		}
+	}
+
+	return apply_filters( 'epl_youtube_embed_url', $url );
 }
 
 /**
@@ -3225,4 +3250,265 @@ function epl_get_post_id_from_unique_id( $unique_id = '' ) {
 	}
 
 	return false;
+}
+
+/**
+ * Renders stickers, based on meta values, an alternative to epl_price_stickers.
+ * 
+ * @param      array  $options   The options
+ * @param      array  $stickers  The stickers
+ * @since      3.4.27 		 
+ */
+function epl_stickers( $options = array(), $stickers = array() ) {
+
+	global $post;
+
+	if( !is_epl_post() )
+		return;
+
+	$default_options = array(
+		'wrap'			=>	false,
+		'wrap_class'	=>	'epl-stickers-wrapper',
+		'wrapper_tag'	=>	'div',
+		'sticker_tag'	=>	'span',
+		'sticker_class'	=>	'status-sticker',
+		'max_stickers'	=>	2
+	);
+
+	$sticker_counts = 0;
+
+	$options = array_merge( $default_options, $options );
+
+	if( empty( $stickers ) )
+		$stickers = epl_get_stickers_array();
+
+	$options = apply_filters( 'epl_stickers_options', $options );
+
+	if( $options[ 'wrap'] )
+		echo '<'.$options[ 'wrapper_tag' ].' class="'.$options[ 'wrap_class' ].'">';
+
+	foreach ( $stickers as $key => $sticker ) {
+
+		if( $sticker_counts == $default_options['max_stickers'] )
+			break; ?>
+
+		<<?php echo esc_attr( $options['sticker_tag'] ) ?> class="<?php echo esc_attr( $options['sticker_class'].' '.$sticker[ 'class' ] ); ?>">
+			<?php
+				echo isset( $sticker[ 'before' ] ) ? 
+				wp_kses_post( $sticker[ 'before' ] ) : '';
+				echo wp_kses_post( $sticker[ 'label' ] );
+				echo isset( $sticker[ 'after' ] ) ? 
+				wp_kses_post( $sticker[ 'after' ] ) : '';
+			?>
+		</<?php echo esc_attr( $options['sticker_tag'] ) ?>> <?php
+
+		$sticker_counts++;
+	}
+
+	if( $options[ 'wrap'] )
+		echo '</'.$options[ 'wrapper_tag' ].'>';
+
+}
+
+/**
+ * Returns stickers array based on type, status etc.
+ * 
+ * @since      3.4.27 		 
+ */
+function epl_get_stickers_array() {
+
+	global $post;
+
+	$stickers = array(
+
+		'under_offer'			=>	array(
+			'conditions'			=>	array(
+				'property_status'			=>	'current',
+				'property_under_offer'		=>	array( 'yes' ),
+			),
+			'type'				=>	epl_get_core_post_types(),
+			'label'				=>	epl_get_option( 'label_under_offer' ),
+			'before'			=>	'',
+			'after'				=>	'',
+			'class'				=>	'under-offer'
+		),
+		'home_open'			=>	array(
+			'conditions'			=>	array(
+				'property_inspection_times'			=>	array( null, ''),
+			),
+			'compare'			=>	'!=',
+			'type'				=>	epl_get_core_post_types(),
+			'label'				=>	epl_get_option( 'label_home_open'),
+			'before'			=>	'',
+			'after'				=>	'',
+			'class'				=>	'open'
+		),
+
+		'new'			=>	array(
+			'type'				=>	epl_get_core_post_types(),
+			'label'				=>	epl_get_option( 'label_new' ),
+			'before'			=>	'',
+			'after'				=>	'',
+			'class'				=>	'new'
+
+		),
+		'rental_lease'	=>	array(
+			'conditions'			=>	array(
+				'property_status'			=>	'current',
+			),
+			'type'				=>	array( 'rental' ),
+			'label'				=>	__( 'For Lease', 'easy-property-listings'),
+			'before'			=>	'',
+			'after'				=>	'',
+			'class'				=>	'for-lease'
+		),
+		'leased'			=>	array(
+			'conditions'			=>	array(
+				'property_status'			=>	'leased',
+			),
+			'type'				=>	array( 'rental', 'commercial_land', 'commercial' ),
+			'label'				=>	epl_get_option( 'label_leased'),
+			'before'			=>	'',
+			'after'				=>	'',
+			'class'				=>	'leased'
+		),
+		'current_sales'			=>	array(
+			'conditions'			=>	array(
+				'property_status'			=>	'current',
+			),
+			'type'				=>	array( 'property', 'rural', 'land', 'business' ),
+			'label'				=>	__( 'For Sale', 'easy-property-listings'),
+			'before'			=>	'',
+			'after'				=>	'',
+			'class'				=>	'for-sale'
+		),
+		'sold'			=>	array(
+			'conditions'			=>	array(
+				'property_status'			=>	'sold',
+			),
+			'type'				=>	epl_get_core_post_types(),
+			'label'				=>	epl_get_option( 'label_sold'),
+			'before'			=>	'',
+			'after'				=>	'',
+			'class'				=>	'sold'
+		),
+		'commercial_sale'			=>	array(
+			'conditions'			=>	array(
+				'property_status'			=>	'current',
+				'property_com_listing_type'	=>	array( 'sale', 'both' ),
+			),
+			'type'				=>	array( 'commercial', 'commercial_land' ),
+			'label'				=>	__( 'For Sale', 'easy-property-listings'),
+			'before'			=>	'',
+			'after'				=>	'',
+			'class'				=>	'for-sale'
+		),
+		'commercial_lease'			=>	array(
+			'conditions'			=>	array(
+				'property_status'			=>	'current',
+				'property_com_listing_type'	=>	array( 'lease' ),
+			),
+			'type'				=>	array( 'commercial', 'commercial_land' ),
+			'label'				=>	__( 'For Lease', 'easy-property-listings'),
+			'before'			=>	'',
+			'after'				=>	'',
+			'class'				=>	'for-lease'
+		)
+		
+	);
+
+	/**
+	 * Hook into this array to add / remove stickers based on conditions.
+	 *
+	 * @var        callable
+	 */
+	$stickers = apply_filters( 'epl_available_stickers', $stickers );
+
+	$return = array();
+
+	foreach ($stickers as $key => $sticker ) {
+		
+		if( !empty( $sticker ) && is_array( $sticker ) ) {
+
+			if( !in_array( get_post_type(), $sticker[ 'type'] ) )
+				continue;
+
+			if( 'new' === $key ) {
+
+				$date          = new DateTime( $post->post_date );
+				$now           = new DateTime();
+
+				// php > 5.3.
+				if ( method_exists( $now, 'diff' ) ) {
+
+					$diff = $now->diff( $date );
+					$diff = $diff->days;
+				} else {
+					$diff = strtotime( $now->format( 'M d Y ' ) ) - strtotime( $date->format( 'M d Y ' ) );
+					$diff = floor( $diff / 3600 / 24 );
+
+				}
+
+				if ( epl_get_option( 'sticker_new_range' ) >= $diff ) { 
+
+					$return[ $key ] = array(
+						'label'		=>	$sticker[ 'label' ],
+						'class'		=>	$sticker[ 'class' ],
+						'before'	=>	$sticker[ 'before' ],
+						'after'		=>	$sticker[ 'after' ]
+					);
+				}
+			} else { 
+
+				$conditions = $sticker[ 'conditions' ];
+				$compare 	= isset( $sticker[ 'compare' ] ) ? $sticker[ 'compare' ] : '=';
+
+				if( !empty( $conditions ) ) {
+
+					foreach ($conditions as $condition_key => $condition_condition ) {
+						
+						if( $compare === '=' ) {
+
+							if( is_array( $condition_condition ) ) {
+								if( !in_array( get_property_meta( $condition_key ), $condition_condition ) ) {
+									continue 2;
+								}
+							} else {
+
+								if( get_property_meta( $condition_key ) !== $condition_condition ) {
+									continue 2;
+								}
+							}
+							
+						} elseif( $compare === '!=' ) {
+							if( is_array( $condition_condition ) ) {
+								if( in_array( get_property_meta( $condition_key ), $condition_condition ) ) {
+									continue 2;
+								}
+							} else {
+
+								if( get_property_meta( $condition_key ) === $condition_condition ) {
+									continue 2;
+								}
+							}
+						}
+
+						$return[ $key ] = array(
+							'label'		=>	$sticker[ 'label' ],
+							'class'		=>	$sticker[ 'class' ],
+							'before'	=>	$sticker[ 'before' ],
+							'after'		=>	$sticker[ 'after' ]
+						);
+					}
+				}
+
+			}
+		}
+	}
+
+	/**
+	 * List of stickers for current listing, hook here if only need to change labels, 
+	 * class etc for displayed labels.
+	 */
+	return apply_filters( 'epl_stickers_array', $return );
 }

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -147,7 +147,6 @@ add_action( 'epl_single_featured_image', 'epl_property_featured_image', 10, 3 );
  *
  * @since      2.2
  * @since        3.4.27 additional param to disable / enable stickers
- *
  */
 function epl_property_archive_featured_image( $image_size = 'epl-image-medium-crop', $image_class = 'teaser-left-thumb', $link = true, $stickers = true ) {
 
@@ -167,7 +166,7 @@ function epl_property_archive_featured_image( $image_size = 'epl-image-medium-cr
 				<a href="<?php the_permalink(); ?>">
 			<?php } ?>
 					<div class="epl-blog-image">
-						<?php if( $stickers ) :  ?>
+						<?php if ( $stickers ) : ?>
 						<div class="epl-stickers-wrapper">
 							<?php echo wp_kses_post( epl_get_price_sticker() ); ?>
 						</div>
@@ -296,8 +295,9 @@ function epl_get_template_part( $template, $arguments = array() ) {
  */
 function epl_archive_custom_excerpt_length( $length ) {
 
-	if( !is_epl_post() ) 
+	if ( ! is_epl_post() ) {
 		return $length;
+	}
 
 	return epl_get_option( 'display_excerpt_length', 22 );
 }
@@ -1060,10 +1060,10 @@ function epl_get_video_html( $property_video_url = '', $width = 600 ) {
 /**
  * Convert embed URLs to non embed URLs for WP Oembed compatiblity.
  *
- * @param      string  $url    The url
+ * @param      string $url    The url
  *
- * @return     string 	converted URL
- * @since 	   3.4.27	
+ * @return     string   converted URL
+ * @since      3.4.27
  */
 function epl_convert_youtube_embed_url( $url ) {
 
@@ -1071,8 +1071,8 @@ function epl_convert_youtube_embed_url( $url ) {
 
 		$video_id = epl_get_youtube_id_from_url( $url );
 
-		if( !empty( $video_id) ) {
-			$url = 'https://www.youtube.com/watch?v='.$video_id;
+		if ( ! empty( $video_id ) ) {
+			$url = 'https://www.youtube.com/watch?v=' . $video_id;
 		}
 	}
 
@@ -3256,66 +3256,73 @@ function epl_get_post_id_from_unique_id( $unique_id = '' ) {
 
 /**
  * Renders stickers, based on meta values, an alternative to epl_price_stickers.
- * 
- * @param      array  $options   The options
- * @param      array  $stickers  The stickers
- * @since      3.4.27 		 
+ *
+ * @param      array $options   The options
+ * @param      array $stickers  The stickers
+ * @since      3.4.27
  */
 function epl_stickers( $options = array(), $stickers = array() ) {
 
 	global $post;
 
-	if( !is_epl_post() )
+	if ( ! is_epl_post() ) {
 		return;
+	}
 
 	$default_options = array(
-		'wrap'			=>	false,
-		'wrap_class'	=>	'epl-stickers-wrapper',
-		'wrapper_tag'	=>	'div',
-		'sticker_tag'	=>	'span',
-		'sticker_class'	=>	'status-sticker',
-		'max_stickers'	=>	2
+		'wrap'          => false,
+		'wrap_class'    => 'epl-stickers-wrapper',
+		'wrapper_tag'   => 'div',
+		'sticker_tag'   => 'span',
+		'sticker_class' => 'status-sticker',
+		'max_stickers'  => 2,
 	);
 
 	$sticker_counts = 0;
 
 	$options = array_merge( $default_options, $options );
 
-	if( empty( $stickers ) )
+	if ( empty( $stickers ) ) {
 		$stickers = epl_get_stickers_array();
+	}
 
 	$options = apply_filters( 'epl_stickers_options', $options );
 
-	if( $options[ 'wrap'] )
-		echo '<'.$options[ 'wrapper_tag' ].' class="'.$options[ 'wrap_class' ].'">';
+	if ( $options['wrap'] ) {
+		echo '<' . $options['wrapper_tag'] . ' class="' . $options['wrap_class'] . '">';
+	}
 
 	foreach ( $stickers as $key => $sticker ) {
 
-		if( $sticker_counts == $default_options['max_stickers'] )
-			break; ?>
+		if ( $sticker_counts == $default_options['max_stickers'] ) {
+			break;
+		}
+		?>
 
-		<<?php echo esc_attr( $options['sticker_tag'] ) ?> class="<?php echo esc_attr( $options['sticker_class'].' '.$sticker[ 'class' ] ); ?>">
+		<<?php echo esc_attr( $options['sticker_tag'] ); ?> class="<?php echo esc_attr( $options['sticker_class'] . ' ' . $sticker['class'] ); ?>">
 			<?php
-				echo isset( $sticker[ 'before' ] ) ? 
-				wp_kses_post( $sticker[ 'before' ] ) : '';
-				echo wp_kses_post( $sticker[ 'label' ] );
-				echo isset( $sticker[ 'after' ] ) ? 
-				wp_kses_post( $sticker[ 'after' ] ) : '';
+				echo isset( $sticker['before'] ) ?
+				wp_kses_post( $sticker['before'] ) : '';
+				echo wp_kses_post( $sticker['label'] );
+				echo isset( $sticker['after'] ) ?
+				wp_kses_post( $sticker['after'] ) : '';
 			?>
-		</<?php echo esc_attr( $options['sticker_tag'] ) ?>> <?php
+		</<?php echo esc_attr( $options['sticker_tag'] ); ?>> 
+					 <?php
 
-		$sticker_counts++;
+						$sticker_counts++;
 	}
 
-	if( $options[ 'wrap'] )
-		echo '</'.$options[ 'wrapper_tag' ].'>';
+	if ( $options['wrap'] ) {
+		echo '</' . $options['wrapper_tag'] . '>';
+	}
 
 }
 
 /**
  * Returns stickers array based on type, status etc.
- * 
- * @since      3.4.27 		 
+ *
+ * @since      3.4.27
  */
 function epl_get_stickers_array() {
 
@@ -3323,100 +3330,100 @@ function epl_get_stickers_array() {
 
 	$stickers = array(
 
-		'under_offer'			=>	array(
-			'conditions'			=>	array(
-				'property_status'			=>	'current',
-				'property_under_offer'		=>	array( 'yes' ),
+		'under_offer'      => array(
+			'conditions' => array(
+				'property_status'      => 'current',
+				'property_under_offer' => array( 'yes' ),
 			),
-			'type'				=>	epl_get_core_post_types(),
-			'label'				=>	epl_get_option( 'label_under_offer' ),
-			'before'			=>	'',
-			'after'				=>	'',
-			'class'				=>	'under-offer'
+			'type'       => epl_get_core_post_types(),
+			'label'      => epl_get_option( 'label_under_offer' ),
+			'before'     => '',
+			'after'      => '',
+			'class'      => 'under-offer',
 		),
-		'home_open'			=>	array(
-			'conditions'			=>	array(
-				'property_inspection_times'			=>	array( null, ''),
+		'home_open'        => array(
+			'conditions' => array(
+				'property_inspection_times' => array( null, '' ),
 			),
-			'compare'			=>	'!=',
-			'type'				=>	epl_get_core_post_types(),
-			'label'				=>	epl_get_option( 'label_home_open'),
-			'before'			=>	'',
-			'after'				=>	'',
-			'class'				=>	'open'
+			'compare'    => '!=',
+			'type'       => epl_get_core_post_types(),
+			'label'      => epl_get_option( 'label_home_open' ),
+			'before'     => '',
+			'after'      => '',
+			'class'      => 'open',
 		),
 
-		'new'			=>	array(
-			'type'				=>	epl_get_core_post_types(),
-			'label'				=>	epl_get_option( 'label_new' ),
-			'before'			=>	'',
-			'after'				=>	'',
-			'class'				=>	'new'
+		'new'              => array(
+			'type'   => epl_get_core_post_types(),
+			'label'  => epl_get_option( 'label_new' ),
+			'before' => '',
+			'after'  => '',
+			'class'  => 'new',
 
 		),
-		'rental_lease'	=>	array(
-			'conditions'			=>	array(
-				'property_status'			=>	'current',
+		'rental_lease'     => array(
+			'conditions' => array(
+				'property_status' => 'current',
 			),
-			'type'				=>	array( 'rental' ),
-			'label'				=>	__( 'For Lease', 'easy-property-listings'),
-			'before'			=>	'',
-			'after'				=>	'',
-			'class'				=>	'for-lease'
+			'type'       => array( 'rental' ),
+			'label'      => __( 'For Lease', 'easy-property-listings' ),
+			'before'     => '',
+			'after'      => '',
+			'class'      => 'for-lease',
 		),
-		'leased'			=>	array(
-			'conditions'			=>	array(
-				'property_status'			=>	'leased',
+		'leased'           => array(
+			'conditions' => array(
+				'property_status' => 'leased',
 			),
-			'type'				=>	array( 'rental', 'commercial_land', 'commercial' ),
-			'label'				=>	epl_get_option( 'label_leased'),
-			'before'			=>	'',
-			'after'				=>	'',
-			'class'				=>	'leased'
+			'type'       => array( 'rental', 'commercial_land', 'commercial' ),
+			'label'      => epl_get_option( 'label_leased' ),
+			'before'     => '',
+			'after'      => '',
+			'class'      => 'leased',
 		),
-		'current_sales'			=>	array(
-			'conditions'			=>	array(
-				'property_status'			=>	'current',
+		'current_sales'    => array(
+			'conditions' => array(
+				'property_status' => 'current',
 			),
-			'type'				=>	array( 'property', 'rural', 'land', 'business' ),
-			'label'				=>	__( 'For Sale', 'easy-property-listings'),
-			'before'			=>	'',
-			'after'				=>	'',
-			'class'				=>	'for-sale'
+			'type'       => array( 'property', 'rural', 'land', 'business' ),
+			'label'      => __( 'For Sale', 'easy-property-listings' ),
+			'before'     => '',
+			'after'      => '',
+			'class'      => 'for-sale',
 		),
-		'sold'			=>	array(
-			'conditions'			=>	array(
-				'property_status'			=>	'sold',
+		'sold'             => array(
+			'conditions' => array(
+				'property_status' => 'sold',
 			),
-			'type'				=>	epl_get_core_post_types(),
-			'label'				=>	epl_get_option( 'label_sold'),
-			'before'			=>	'',
-			'after'				=>	'',
-			'class'				=>	'sold'
+			'type'       => epl_get_core_post_types(),
+			'label'      => epl_get_option( 'label_sold' ),
+			'before'     => '',
+			'after'      => '',
+			'class'      => 'sold',
 		),
-		'commercial_sale'			=>	array(
-			'conditions'			=>	array(
-				'property_status'			=>	'current',
-				'property_com_listing_type'	=>	array( 'sale', 'both' ),
+		'commercial_sale'  => array(
+			'conditions' => array(
+				'property_status'           => 'current',
+				'property_com_listing_type' => array( 'sale', 'both' ),
 			),
-			'type'				=>	array( 'commercial', 'commercial_land' ),
-			'label'				=>	__( 'For Sale', 'easy-property-listings'),
-			'before'			=>	'',
-			'after'				=>	'',
-			'class'				=>	'for-sale'
+			'type'       => array( 'commercial', 'commercial_land' ),
+			'label'      => __( 'For Sale', 'easy-property-listings' ),
+			'before'     => '',
+			'after'      => '',
+			'class'      => 'for-sale',
 		),
-		'commercial_lease'			=>	array(
-			'conditions'			=>	array(
-				'property_status'			=>	'current',
-				'property_com_listing_type'	=>	array( 'lease' ),
+		'commercial_lease' => array(
+			'conditions' => array(
+				'property_status'           => 'current',
+				'property_com_listing_type' => array( 'lease' ),
 			),
-			'type'				=>	array( 'commercial', 'commercial_land' ),
-			'label'				=>	__( 'For Lease', 'easy-property-listings'),
-			'before'			=>	'',
-			'after'				=>	'',
-			'class'				=>	'for-lease'
-		)
-		
+			'type'       => array( 'commercial', 'commercial_land' ),
+			'label'      => __( 'For Lease', 'easy-property-listings' ),
+			'before'     => '',
+			'after'      => '',
+			'class'      => 'for-lease',
+		),
+
 	);
 
 	/**
@@ -3428,17 +3435,18 @@ function epl_get_stickers_array() {
 
 	$return = array();
 
-	foreach ($stickers as $key => $sticker ) {
-		
-		if( !empty( $sticker ) && is_array( $sticker ) ) {
+	foreach ( $stickers as $key => $sticker ) {
 
-			if( !in_array( get_post_type(), $sticker[ 'type'] ) )
+		if ( ! empty( $sticker ) && is_array( $sticker ) ) {
+
+			if ( ! in_array( get_post_type(), $sticker['type'] ) ) {
 				continue;
+			}
 
-			if( 'new' === $key ) {
+			if ( 'new' === $key ) {
 
-				$date          = new DateTime( $post->post_date );
-				$now           = new DateTime();
+				$date = new DateTime( $post->post_date );
+				$now  = new DateTime();
 
 				// php > 5.3.
 				if ( method_exists( $now, 'diff' ) ) {
@@ -3451,65 +3459,63 @@ function epl_get_stickers_array() {
 
 				}
 
-				if ( epl_get_option( 'sticker_new_range' ) >= $diff ) { 
+				if ( epl_get_option( 'sticker_new_range' ) >= $diff ) {
 
 					$return[ $key ] = array(
-						'label'		=>	$sticker[ 'label' ],
-						'class'		=>	$sticker[ 'class' ],
-						'before'	=>	$sticker[ 'before' ],
-						'after'		=>	$sticker[ 'after' ]
+						'label'  => $sticker['label'],
+						'class'  => $sticker['class'],
+						'before' => $sticker['before'],
+						'after'  => $sticker['after'],
 					);
 				}
-			} else { 
+			} else {
 
-				$conditions = $sticker[ 'conditions' ];
-				$compare 	= isset( $sticker[ 'compare' ] ) ? $sticker[ 'compare' ] : '=';
+				$conditions = $sticker['conditions'];
+				$compare    = isset( $sticker['compare'] ) ? $sticker['compare'] : '=';
 
-				if( !empty( $conditions ) ) {
+				if ( ! empty( $conditions ) ) {
 
-					foreach ($conditions as $condition_key => $condition_condition ) {
-						
-						if( $compare === '=' ) {
+					foreach ( $conditions as $condition_key => $condition_condition ) {
 
-							if( is_array( $condition_condition ) ) {
-								if( !in_array( get_property_meta( $condition_key ), $condition_condition ) ) {
+						if ( $compare === '=' ) {
+
+							if ( is_array( $condition_condition ) ) {
+								if ( ! in_array( get_property_meta( $condition_key ), $condition_condition ) ) {
 									continue 2;
 								}
 							} else {
 
-								if( get_property_meta( $condition_key ) !== $condition_condition ) {
+								if ( get_property_meta( $condition_key ) !== $condition_condition ) {
 									continue 2;
 								}
 							}
-							
-						} elseif( $compare === '!=' ) {
-							if( is_array( $condition_condition ) ) {
-								if( in_array( get_property_meta( $condition_key ), $condition_condition ) ) {
+						} elseif ( $compare === '!=' ) {
+							if ( is_array( $condition_condition ) ) {
+								if ( in_array( get_property_meta( $condition_key ), $condition_condition ) ) {
 									continue 2;
 								}
 							} else {
 
-								if( get_property_meta( $condition_key ) === $condition_condition ) {
+								if ( get_property_meta( $condition_key ) === $condition_condition ) {
 									continue 2;
 								}
 							}
 						}
 
 						$return[ $key ] = array(
-							'label'		=>	$sticker[ 'label' ],
-							'class'		=>	$sticker[ 'class' ],
-							'before'	=>	$sticker[ 'before' ],
-							'after'		=>	$sticker[ 'after' ]
+							'label'  => $sticker['label'],
+							'class'  => $sticker['class'],
+							'before' => $sticker['before'],
+							'after'  => $sticker['after'],
 						);
 					}
 				}
-
 			}
 		}
 	}
 
 	/**
-	 * List of stickers for current listing, hook here if only need to change labels, 
+	 * List of stickers for current listing, hook here if only need to change labels,
 	 * class etc for displayed labels.
 	 */
 	return apply_filters( 'epl_stickers_array', $return );

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -140,12 +140,14 @@ add_action( 'epl_single_featured_image', 'epl_property_featured_image', 10, 3 );
 /**
  * Featured Image on archive template now loading through filter
  *
- * @since      2.2
- * @since 		3.4.27 additional param to disable / enable stickers
+ * @param string $image_size  The image size.
+ * @param string $image_class The image class.
+ * @param bool   $link        Enable or disable the link with true/false. Default true.
+ * @param bool   $stickers    Enable or disable the stickers with true/false. Default true.
  *
- * @param      string  $image_size   The image size.
- * @param      string  $image_class  The image class.
- * @param      boolean $link         The link.
+ * @since      2.2
+ * @since        3.4.27 additional param to disable / enable stickers
+ *
  */
 function epl_property_archive_featured_image( $image_size = 'epl-image-medium-crop', $image_class = 'teaser-left-thumb', $link = true, $stickers = true ) {
 

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -811,10 +811,10 @@ function epl_get_property_icons( $args = array(), $returntype = 'i' ) {
 /**
  * Property icons
  *
- * @param string $returntype  The returntype.
+ * @param string $returntype The returntype.
  *
  * @since 1.0.0
- * @since 3.3.0 Revides.
+ * @since 3.3.0 Revised.
  */
 function epl_property_icons( $returntype = 'i' ) {
 	$returntype = empty( $returntype ) ? 'i' : $returntype;
@@ -1058,12 +1058,12 @@ function epl_get_video_html( $property_video_url = '', $width = 600 ) {
 }
 
 /**
- * Convert embed URLs to non embed URLs for WP Oembed compatiblity.
+ * Convert embed URLs to non embed URLs for WP Oembed compatibility.
  *
- * @param      string $url    The url
+ * @param  string $url The url.
  *
- * @return     string   converted URL
- * @since      3.4.27
+ * @return string   converted URL
+ * @since  3.4.27
  */
 function epl_convert_youtube_embed_url( $url ) {
 
@@ -3077,7 +3077,7 @@ add_action( 'epl_property_search_not_found', 'epl_property_search_not_found_call
  * @return     array
  *
  * @since 3.1.16
- * @since 3.4.23 Added compatiblity class.
+ * @since 3.4.23 Added compatibility class.
  */
 function epl_property_post_class_listing_status_callback( $classes ) {
 

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -3480,7 +3480,7 @@ function epl_get_stickers_array() {
 						if ( '=' === $compare ) {
 
 							if ( is_array( $condition_condition ) ) {
-								if ( ! in_array( get_property_meta( $condition_key ), $condition_condition ) ) {
+								if ( ! in_array( get_property_meta( $condition_key ), $condition_condition, true ) ) {
 									continue 2;
 								}
 							} else {
@@ -3489,9 +3489,9 @@ function epl_get_stickers_array() {
 									continue 2;
 								}
 							}
-						} elseif ( $compare === '!=' ) {
+						} elseif ( '!=' === $compare ) {
 							if ( is_array( $condition_condition ) ) {
-								if ( in_array( get_property_meta( $condition_key ), $condition_condition ) ) {
+								if ( in_array( get_property_meta( $condition_key ), $condition_condition, true ) ) {
 									continue 2;
 								}
 							} else {

--- a/lib/post-types/post-types.php
+++ b/lib/post-types/post-types.php
@@ -515,11 +515,14 @@ function epl_manage_listing_column_price_callback() {
 	// Commercial Listing Lease Type Price.
 	if ( 'commercial' === $post->post_type && 'lease' === $property->get_property_meta( 'property_com_listing_type' ) ) {
 
-		// Needs consideration and configuring property_com_listing_type.
-		// Needs consideration and configuring property_com_rent.
-		// Needs consideration and configuring property_com_rent_period.
-		// Needs consideration and configuring property_com_rent_range_min.
-		// Needs consideration and configuring property_com_rent_range_max.
+		/**
+		 * TODO: Commercial features consideration.
+		 * Needs consideration and configuring property_com_listing_type.
+		 * Needs consideration and configuring property_com_rent.
+		 * Needs consideration and configuring property_com_rent_period.
+		 * Needs consideration and configuring property_com_rent_range_min.
+		 * Needs consideration and configuring property_com_rent_range_max.
+		 */
 
 		$price = $property->get_property_meta( 'property_com_rent' );
 

--- a/lib/post-types/post-types.php
+++ b/lib/post-types/post-types.php
@@ -303,17 +303,19 @@ function epl_manage_listing_column_listing_callback() {
 		echo '<div class="epl_meta_category">' , esc_html( $commercial_category ) , '</div>';
 	}
 
-	// Need to factor in business category: <businessCategory id="1">.
-	// Need to factor in business category: <name>Food/Hospitality</name>.
-	// Need to factor in business category: <businessSubCategory>.
-	// Need to factor in business category: <name>Takeaway Food</name>.
-	// Need to factor in business category: </businessSubCategory>.
-	// Need to factor in business category: </businessCategory>.
-	// Need to factor in business category: <businessCategory id="2"/>.
-	// Need to factor in business category: <businessCategory id="3"/>.
-
-	// Need to factor in business fields: property_bus_takings (number).
-	// Need to factor in business fields: property_bus_franchise (yes/no).
+	/**
+	 * TODO: Factor in Business category.
+	 * Need to factor in business category: <businessCategory id="1">.
+	 * Need to factor in business category: <name>Food/Hospitality</name>.
+	 * Need to factor in business category: <businessSubCategory>.
+	 * Need to factor in business category: <name>Takeaway Food</name>.
+	 * Need to factor in business category: </businessSubCategory>.
+	 * Need to factor in business category: </businessCategory>.
+	 * Need to factor in business category: <businessCategory id="2"/>.
+	 * Need to factor in business category: <businessCategory id="3"/>.
+	 * Need to factor in business fields: property_bus_takings (number).
+	 * Need to factor in business fields: property_bus_franchise (yes/no).
+	 */
 
 	// Listing Location Taxonomy.
 	echo '<div class="type_suburb">' , wp_kses(

--- a/lib/post-types/post-types.php
+++ b/lib/post-types/post-types.php
@@ -298,7 +298,7 @@ function epl_manage_listing_column_listing_callback() {
 		) , '</strong></div>';
 	}
 
-	// Category for commercial listing lype.
+	// Category for commercial listing type.
 	if ( ! empty( $commercial_category ) ) {
 		echo '<div class="epl_meta_category">' , esc_html( $commercial_category ) , '</div>';
 	}
@@ -391,7 +391,7 @@ add_action( 'epl_manage_listing_column_listing', 'epl_manage_listing_column_list
  * Get Listing Labels.
  *
  * @param array  $args Array of arguments.
- * @param string $returntype The type of retunr formatting filterable with epl_manage_listing_column_labels_return_type.
+ * @param string $returntype The type of return formatting filterable with epl_manage_listing_column_labels_return_type.
  *
  * @return false|string
  * @since 3.3
@@ -430,7 +430,7 @@ function epl_get_manage_listing_column_labels( $args = array(), $returntype = 'l
  * Featured Listing Label to Listing Details column.
  *
  * @since 3.3
- * @param string $returntype The type of retunr formatting filterable with epl_manage_listing_column_labels_return_type.
+ * @param string $returntype The type of return formatting filterable with epl_manage_listing_column_labels_return_type.
  */
 function epl_manage_listing_column_labels_callback( $returntype = 'l' ) {
 

--- a/lib/post-types/post-types.php
+++ b/lib/post-types/post-types.php
@@ -264,8 +264,8 @@ function epl_manage_listing_column_listing_callback() {
 
 	$property_address_suburb = get_the_term_list( $post->ID, 'location', '', ', ', '' );
 	$heading                 = $property->get_property_meta( 'property_heading' );
-	$homeopen                = $property->get_property_meta( 'property_inspection_times' );
-	$homeopen                = trim( $homeopen );
+	$home_open                = $property->get_property_meta( 'property_inspection_times' );
+	$home_open                = trim( $home_open );
 	$beds                    = $property->get_property_meta( 'property_bedrooms' );
 	$baths                   = $property->get_property_meta( 'property_bathrooms' );
 	$rooms                   = $property->get_property_meta( 'property_rooms', false );
@@ -375,14 +375,14 @@ function epl_manage_listing_column_listing_callback() {
 	}
 
 	// Home Open date and time.
-	if ( ! empty( $homeopen ) ) {
-		$homeopen          = array_filter( explode( "\n", $homeopen ) );
-			$homeopen_list = '<ul class="epl_meta_home_open">';
-		foreach ( $homeopen as $num => $item ) {
-			$homeopen_list .= '<li>' . htmlspecialchars( $item ) . '</li>';
+	if ( ! empty( $home_open ) ) {
+		$home_open          = array_filter( explode( "\n", $home_open ) );
+			$home_open_list = '<ul class="epl_meta_home_open">';
+		foreach ( $home_open as $num => $item ) {
+			$home_open_list .= '<li>' . htmlspecialchars( $item ) . '</li>';
 		}
-			$homeopen_list .= '</ul>';
-		echo '<div class="epl_meta_home_open_label"><span class="home-open"><strong>' . esc_html( epl_labels( 'label_home_open' ) ) . '</strong></span>' , wp_kses_post( $homeopen_list ) , '</div>';
+			$home_open_list .= '</ul>';
+		echo '<div class="epl_meta_home_open_label"><span class="home-open"><strong>' . esc_html( epl_labels( 'label_home_open' ) ) . '</strong></span>' , wp_kses_post( $home_open_list ) , '</div>';
 	}
 }
 add_action( 'epl_manage_listing_column_listing', 'epl_manage_listing_column_listing_callback' );
@@ -546,9 +546,9 @@ function epl_manage_listing_column_price_callback() {
 
 	// If we have a price to display in the bar.
 	if ( ! empty( $bar_price ) ) {
-		$barwidth = 0 === $max_price ? 0 : $bar_price / $max_price * 100;
+		$bar_width = 0 === $max_price ? 0 : $bar_price / $max_price * 100;
 		echo '<div class="epl-price-bar ' . esc_html( $class ) . '">
-			<span style="width:' . esc_html( $barwidth ) . '%"></span>
+			<span style="width:' . esc_html( $bar_width ) . '%"></span>
 		</div>';
 		// Otherwise, there is no price set.
 	} else {

--- a/lib/post-types/post-types.php
+++ b/lib/post-types/post-types.php
@@ -369,7 +369,7 @@ function epl_manage_listing_column_listing_callback() {
 		}
 		$land_unit = apply_filters( 'epl_property_land_area_unit_label', $land_unit );
 
-		echo '<span class="epl_meta_land_unit"> ' , esc_attr( $land_unit ) , '</span>';
+		echo '<span class="epl_meta_land_unit"> ' , wp_kses_post( $land_unit ) , '</span>';
 		echo '</div>';
 	}
 

--- a/lib/post-types/post-types.php
+++ b/lib/post-types/post-types.php
@@ -257,6 +257,7 @@ add_action( 'epl_manage_listing_column_property_thumb', 'epl_manage_listing_colu
  * @since 1.0.0
  * @since 3.4.23 Altered the admin output of property_category to use the label instead of value.
  * @since 3.4.23 Added land unit filter epl_property_land_area_unit_label to admin area when viewing listings.
+ * @since 3.4.27 Fixed html escaping issue and formatting for land size.
  */
 function epl_manage_listing_column_listing_callback() {
 	global $post,$property;
@@ -362,7 +363,7 @@ function epl_manage_listing_column_listing_callback() {
 	// Land area.
 	if ( ! empty( $land ) ) {
 		echo '<div class="epl_meta_land_details">';
-		echo '<span class="epl_meta_land">' , esc_attr( $land ) , '</span>';
+		echo '<span class="epl_meta_land">' , wp_kses_post( epl_format_amount( $land, true ) ) , '</span>';
 
 		if ( 'squareMeter' === $land_unit ) {
 			$land_unit = esc_html__( 'm&#178;', 'easy-property-listings' );
@@ -560,7 +561,7 @@ function epl_manage_listing_column_price_callback() {
 		echo 'Sold' === $property_status ? esc_html( epl_currency_formatted_amount( $sold_price ) ) : '';
 		echo '</div>';
 	} else {
-		echo '<div class="epl_meta_price">' . esc_html( $property->get_price_plain_value() ) . '</div>';
+		echo '<div class="epl_meta_price">' . wp_kses_post( $property->get_price_plain_value() ) . '</div>';
 	}
 
 	// Bond for rental listing type.

--- a/lib/shortcodes/shortcode-listing-tax-feature.php
+++ b/lib/shortcodes/shortcode-listing-tax-feature.php
@@ -27,6 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @return false|string|void
  * @since       1.1.2
+ * @since 		3.4.27 fixed the issue : no spaces between classes when both class & template attributs are set.
  */
 function epl_shortcode_listing_tax_feature_callback( $atts ) {
 	$property_types = epl_get_active_post_types();
@@ -183,7 +184,7 @@ function epl_shortcode_listing_tax_feature_callback( $atts ) {
 		<div class="loop epl-shortcode">
 			<div class="loop-content epl-shortcode-listing-feature
 			<?php
-			echo esc_attr( epl_template_class( $template, 'archive' ) );
+			echo esc_attr( epl_template_class( $template, 'archive' ) ).' ';
 			echo esc_attr( $attributes['class'] );
 			?>
 			">

--- a/readme.txt
+++ b/readme.txt
@@ -408,6 +408,11 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 
 == Changelog ==
 
+= 3.4.27 May 13, 2020 =
+
+* Tweak: Helper class epl-grid-hidden block display on list mode.
+* Fix: Admin side issue with land size displaying html.
+
 = 3.4.26 April 15, 2020 =
 
 * New: Added Avada theme support.

--- a/readme.txt
+++ b/readme.txt
@@ -408,14 +408,11 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 
 == Changelog ==
 
-The change log can now be found her at Easy Property Listings. This change was made to aid translators in translating the plugin to 100% and not need to translate the long change log items.
+The [change log](https://easypropertylistings.com.au/change-log/?utm_source=readme&utm_medium=change_log_tab&utm_content=changes&utm_campaign=epl_change_log) can now be found [here at Easy Property Listings](https://easypropertylistings.com.au/change-log/?utm_source=readme&utm_medium=change_log_tab&utm_content=changes&utm_campaign=epl_change_log). This change was made to aid translators in translating the plugin to 100% and not need to translate the long change log items.
 
 = 3.4.27 May 22, 2020 =
 
-
-REMOVED CHANGE LOG
-
-
+* New: Removed change log from plugin, this change was made to aid translators in translating the plugin to 100% and not need to translate the long change log items.
 * New: Added sticker support to allow the disabling of image stickers to the epl_property_archive_featured_image function.
 * New: Added filter epl_inspection_link to handle inspection time link. Allowing handling of non date inspection values in the get_property_inspection_times function.
 * New: Added prefix support to epl_get_the_address helper function.
@@ -428,7 +425,6 @@ REMOVED CHANGE LOG
 * Fix: Issue with excerpt length option not working correctly with some themes.
 * Fix: Depreciated epl_excerpt_length function and filter. Retained function for compatibility.
 * Fix: No spaces between classes when both class & template attributes are set.
-
 
 = 3.4.26 April 15, 2020 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -408,10 +408,26 @@ Yes, through the addition of one or more of the add-on integrations, you can qui
 
 == Changelog ==
 
-= 3.4.27 May 13, 2020 =
+The change log can now be found her at Easy Property Listings. This change was made to aid translators in translating the plugin to 100% and not need to translate the long change log items.
 
+= 3.4.27 May 22, 2020 =
+
+
+REMOVED CHANGE LOG
+
+
+* New: Added sticker support to allow the disabling of image stickers to the epl_property_archive_featured_image function.
+* New: Added filter epl_inspection_link to handle inspection time link. Allowing handling of non date inspection values in the get_property_inspection_times function.
+* New: Added prefix support to epl_get_the_address helper function.
+* New: Stickers helper function epl_stickers which renders stickers, based on meta values, an alternative to the epl_price_stickers function.
 * Tweak: Helper class epl-grid-hidden block display on list mode.
-* Fix: Admin side issue with land size displaying html.
+* Tweak: Better support for various YouTube style links.
+* Fix: Escaping issue and formatting for land size in admin.
+* Fix: Dashboard activity widget comment positioning.
+* Fix: Translation issue with rent period.
+* Fix: Issue with excerpt length option not working correctly with some themes.
+* Fix: No spaces between classes when both class & template attributes are set.
+
 
 = 3.4.26 April 15, 2020 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -426,6 +426,7 @@ REMOVED CHANGE LOG
 * Fix: Dashboard activity widget comment positioning.
 * Fix: Translation issue with rent period.
 * Fix: Issue with excerpt length option not working correctly with some themes.
+* Fix: Depreciated epl_excerpt_length function and filter. Retained function for compatibility.
 * Fix: No spaces between classes when both class & template attributes are set.
 
 


### PR DESCRIPTION
* New: Removed change log from plugin, this change was made to aid translators in translating the plugin to 100% and not need to translate the long change log items.
* New: Added sticker support to allow the disabling of image stickers to the epl_property_archive_featured_image function.
* New: Added filter epl_inspection_link to handle inspection time link. Allowing handling of non date inspection values in the get_property_inspection_times function.
* New: Added prefix support to epl_get_the_address helper function.
* New: Stickers helper function epl_stickers which renders stickers, based on meta values, an alternative to the epl_price_stickers function.
* Tweak: Helper class epl-grid-hidden block display on list mode.
* Tweak: Better support for various YouTube style links.
* Fix: Escaping issue and formatting for land size in admin.
* Fix: Dashboard activity widget comment positioning.
* Fix: Translation issue with rent period.
* Fix: Issue with excerpt length option not working correctly with some themes.
* Fix: Depreciated epl_excerpt_length function and filter. Retained function for compatibility.
* Fix: No spaces between classes when both class & template attributes are set.