### PR TITLE
3.4.28 master

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ There are various ways you can contribute:
 
 * New: Option added to number formatting function to trim decimal numbers. 
 * New: Admin filter epl_land_value_decimal_format for land value decimal formatting.
-* New: Globally loading shortcodes and widgets in order to allow page builders to use widgets and render shortcodes when using front-end page builder views..
+* New: Globally loading shortcodes and widgets in order to allow page builders to use widgets. Additionally this will now render shortcodes when using front-end page builders.
 * New: Helper action epl_property_status used to output the listing status in templates.
 * Tweak: Enhancements to the new stickers function.
 * Tweak. Altered land formatting in admin to remove decimals from land values unless they have decimal places.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ There are various ways you can contribute:
 
 * New: Option added to number formatting function to trim decimal numbers. 
 * New: Admin filter epl_land_value_decimal_format for land value decimal formatting.
-* New: Globally loading shortcodes and widgets in order to allow page builders to use widgets.
+* New: Globally loading shortcodes and widgets in order to allow page builders to use widgets and render shortcodes when using front-end page builder views..
 * New: Helper action epl_property_status used to output the listing status in templates.
 * Tweak: Enhancements to the new stickers function.
 * Tweak. Altered land formatting in admin to remove decimals from land values unless they have decimal places.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ There are various ways you can contribute:
 
 ## Change Log ##
 
+= 3.4.28 May 25, 2020 =
+
+* New: Globally loading shortcodes and widgets in order to allow page builders to use widgets.
+* New: Helper action epl_property_status used to output the listing status in templates.
+* Tweak: Enhancements to the new stickers function. 
+
 = 3.4.27 May 22, 2020 =
 
 * New: Removed change log from plugin, this change was made to aid translators in translating the plugin to 100% and not need to translate the long change log items.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ There are various ways you can contribute:
 
 = 3.4.28 May 25, 2020 =
 
+* New: Option added to number formatting function to trim decimal numbers. 
+* New: Admin filter epl_land_value_decimal_format for land value decimal formatting.
 * New: Globally loading shortcodes and widgets in order to allow page builders to use widgets.
 * New: Helper action epl_property_status used to output the listing status in templates.
-* Tweak: Enhancements to the new stickers function. 
+* Tweak: Enhancements to the new stickers function.
+* Tweak. Altered land formatting in admin to remove decimals from land values unless they have decimal places.
 
 = 3.4.27 May 22, 2020 =
 

--- a/apigen.neon
+++ b/apigen.neon
@@ -21,7 +21,7 @@ charset: [UTF-8]
 main: EPL
 
 # title of generated documentation
-title: Easy Property Listings 3.4.27 Code Reference
+title: Easy Property Listings 3.4.28 Code Reference
 
 # base url used for sitemap (useful for public doc)
 baseUrl: http://docs.easypropertylistings.com.au/

--- a/easy-property-listings.php
+++ b/easy-property-listings.php
@@ -5,7 +5,7 @@
  * Description:  Fast. Flexible. Forward-thinking solution for real estate agents using WordPress. Easy Property Listing is one of the most dynamic and feature rich Real Estate plugin for WordPress available on the market today. Built for scale, contact generation and works with any theme!
  * Author: Merv Barrett
  * Author URI: http://www.realestateconnected.com.au/
- * Version: 3.4.27
+ * Version: 3.4.28
  * Text Domain: easy-property-listings
  * Domain Path: languages
  *
@@ -25,7 +25,7 @@
  * @package EPL
  * @category Core
  * @author Merv Barrett
- * @version 3.4.27
+ * @version 3.4.28
  */
 
 // Exit if accessed directly.
@@ -95,7 +95,7 @@ if ( ! class_exists( 'Easy_Property_Listings' ) ) :
 		public function setup_constants() {
 			// Plugin version.
 			if ( ! defined( 'EPL_PROPERTY_VER' ) ) {
-				define( 'EPL_PROPERTY_VER', '3.4.27' );
+				define( 'EPL_PROPERTY_VER', '3.4.28' );
 			}
 			// Plugin DB version.
 			if ( ! defined( 'EPL_PROPERTY_DB_VER' ) ) {

--- a/languages/easy-property-listings.pot
+++ b/languages/easy-property-listings.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Easy Property Listings package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Easy Property Listings 3.4.27\n"
+"Project-Id-Version: Easy Property Listings 3.4.28\n"
 "Report-Msgid-Bugs-To: "
 "http://wordpress.org/support/plugin/easy-property-listings\n"
 "POT-Creation-Date: 2020-05-22 02:28:44+00:00\n"

--- a/languages/easy-property-listings.pot
+++ b/languages/easy-property-listings.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Easy Property Listings 3.4.28\n"
 "Report-Msgid-Bugs-To: "
 "http://wordpress.org/support/plugin/easy-property-listings\n"
-"POT-Creation-Date: 2020-05-22 02:28:44+00:00\n"
+"POT-Creation-Date: 2020-05-25 05:24:44+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -606,7 +606,7 @@ msgstr ""
 
 #: lib/includes/admin/contacts/contact-actions.php:1245
 #: lib/includes/functions.php:2550 lib/post-types/post-types.php:54
-#: lib/post-types/post-types.php:604
+#: lib/post-types/post-types.php:610
 #: lib/widgets/class-epl-widget-recent-property.php:186
 #: lib/widgets/class-epl-widget-recent-property.php:334
 #: lib/widgets/widget-admin-dashboard.php:140
@@ -2734,8 +2734,8 @@ msgstr ""
 #: lib/includes/class-epl-property-meta.php:838
 #: lib/includes/class-epl-property-meta.php:844
 #: lib/includes/class-epl-property-meta.php:1029
-#: lib/includes/functions.php:2613 lib/includes/template-functions.php:3389
-#: lib/includes/template-functions.php:3410
+#: lib/includes/functions.php:2613 lib/includes/template-functions.php:3396
+#: lib/includes/template-functions.php:3428
 msgid "For Sale"
 msgstr ""
 
@@ -2750,8 +2750,8 @@ msgstr ""
 #: lib/includes/class-epl-property-meta.php:886
 #: lib/includes/class-epl-property-meta.php:1042
 #: lib/includes/class-epl-property-meta.php:1044
-#: lib/includes/template-functions.php:3369
-#: lib/includes/template-functions.php:3421
+#: lib/includes/template-functions.php:3376
+#: lib/includes/template-functions.php:3439
 msgid "For Lease"
 msgstr ""
 
@@ -2820,7 +2820,7 @@ msgstr ""
 
 #: lib/includes/class-epl-property-meta.php:1610
 #: lib/includes/class-epl-property-meta.php:1681
-#: lib/post-types/post-types.php:371
+#: lib/post-types/post-types.php:377
 msgid "m&#178;"
 msgstr ""
 
@@ -3825,7 +3825,7 @@ msgid "Under Contract"
 msgstr ""
 
 #: lib/includes/functions.php:2551 lib/post-types/post-types.php:55
-#: lib/post-types/post-types.php:605
+#: lib/post-types/post-types.php:611
 #: lib/widgets/class-epl-widget-recent-property.php:189
 #: lib/widgets/class-epl-widget-recent-property.php:337
 #: lib/widgets/widget-admin-dashboard.php:150
@@ -3835,7 +3835,7 @@ msgid "Withdrawn"
 msgstr ""
 
 #: lib/includes/functions.php:2552 lib/post-types/post-types.php:56
-#: lib/post-types/post-types.php:606
+#: lib/post-types/post-types.php:612
 #: lib/widgets/class-epl-widget-recent-property.php:190
 #: lib/widgets/class-epl-widget-recent-property.php:338
 #: lib/widgets/widget-admin-dashboard.php:155
@@ -4127,6 +4127,10 @@ msgstr ""
 
 #: lib/includes/template-functions.php:3159
 msgid "Email is required"
+msgstr ""
+
+#: lib/includes/template-functions.php:3417
+msgid "For Sale & Lease"
 msgstr ""
 
 #: lib/includes/user.php:27
@@ -5172,15 +5176,15 @@ msgstr ""
 msgid "Room"
 msgstr ""
 
-#: lib/post-types/post-types.php:473
+#: lib/post-types/post-types.php:479
 msgid "No"
 msgstr ""
 
-#: lib/post-types/post-types.php:560
+#: lib/post-types/post-types.php:566
 msgid "No price set"
 msgstr ""
 
-#: lib/post-types/post-types.php:579
+#: lib/post-types/post-types.php:585
 msgid "Lease End:"
 msgstr ""
 

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -2075,8 +2075,6 @@ class EPL_Property_Meta {
 		}
 	}
 
-
-
 	/**
 	 * Get Additional Commercial Features by meta key
 	 *

--- a/lib/includes/formatting.php
+++ b/lib/includes/formatting.php
@@ -50,11 +50,13 @@ function epl_sanitize_amount( $amount ) {
 /**
  * Returns a nicely formatted amount.
  *
- * @param string $amount Price amount to format.
- * @param bool   $decimals Whether or not to use decimals.  Useful when set to false for non-currency numbers.
- * @param bool $preserve_format Whether to preserve amount format ie int / floats.
+ * @param string $amount          Price amount to format.
+ * @param bool   $decimals        Whether or not to use decimals.  Useful when set to false for non-currency numbers.
+ * @param bool   $preserve_format Whether to preserve amount format ie int / floats.
+ *
  * @return string $amount Newly formatted amount or Price Not Available
- * @since 1.0
+ *
+ * @since 1.0.0
  * @since 3.4.28 $preserve_format param added.
  */
 function epl_format_amount( $amount, $decimals = false, $preserve_format = false ) {
@@ -77,7 +79,7 @@ function epl_format_amount( $amount, $decimals = false, $preserve_format = false
 	if ( empty( $amount ) ) {
 		$amount = 0;
 	}
-	if( $preserve_format && false === ( strpos( $amount, $decimal_sep ) ) ) {
+	if ( $preserve_format && false === ( strpos( $amount, $decimal_sep ) ) ) {
 		$decimals = false;
 	}
 

--- a/lib/includes/formatting.php
+++ b/lib/includes/formatting.php
@@ -51,7 +51,7 @@ function epl_sanitize_amount( $amount ) {
  * Returns a nicely formatted amount.
  *
  * @param string $amount          Price amount to format.
- * @param bool   $decimals        Whether or not to use decimals.  Useful when set to false for non-currency numbers.
+ * @param bool   $decimals        Whether or not to use decimals. Useful when set to false for non-currency numbers.
  * @param bool   $preserve_format Whether to preserve amount format ie int / floats.
  *
  * @return string $amount Newly formatted amount or Price Not Available

--- a/lib/includes/functions.php
+++ b/lib/includes/functions.php
@@ -391,7 +391,7 @@ function epl_the_address( $before = '', $after = '', $country = false, $echo = t
  *
  * @return string
  * @since 3.3
- * @since 3.4.27    Added support for prefix.
+ * @since 3.4.27 Added support for prefix.
  */
 function epl_get_the_address( $address_args = array(), $sep = array(), $country = false, $prefix = array() ) {
 

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -145,8 +145,8 @@ add_action( 'epl_single_featured_image', 'epl_property_featured_image', 10, 3 );
  * @param bool   $link        Enable or disable the link with true/false. Default true.
  * @param bool   $stickers    Enable or disable the stickers with true/false. Default true.
  *
- * @since      2.2
- * @since        3.4.27 additional param to disable / enable stickers
+ * @since 2.2
+ * @since 3.4.27 additional param to disable / enable stickers
  */
 function epl_property_archive_featured_image( $image_size = 'epl-image-medium-crop', $image_class = 'teaser-left-thumb', $link = true, $stickers = true ) {
 

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -3322,7 +3322,12 @@ function epl_stickers( $options = array(), $stickers = array() ) {
 /**
  * Returns stickers array based on type, status etc.
  *
- * @since      3.4.27
+ * @param array $sticker_keys Array of keys.
+ *
+ * @return mixed|void
+ *
+ * @since 3.4.28 Added array and filter.
+ * @since 3.4.27
  */
 function epl_get_stickers_array( $sticker_keys = array() ) {
 
@@ -3440,7 +3445,7 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 	/**
 	 * Hook into this array to add / remove stickers based on conditions.
 	 *
-	 * @var        callable
+	 * @var callable
 	 */
 	$stickers = apply_filters( 'epl_available_stickers', $stickers );
 
@@ -3515,8 +3520,11 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 /**
  * Check if sticker condition is valid.
  *
- * @param      <type> $condition  The condition
- * @since       3.4.28
+ * @param string $condition The condition.
+ * @param string $compare   Comparison.
+ *
+ * @return bool
+ * @since 3.4.28
  */
 function epl_sticker_is_condition_valid( $condition, $compare = '=' ) {
 
@@ -3545,9 +3553,10 @@ function epl_sticker_is_condition_valid( $condition, $compare = '=' ) {
 /**
  * Property Status Labels.
  *
- * @param      array $statues  The statues
- * @param      array $options  The options
- * @since      3.4.28
+ * @param array $statues  The statues.
+ * @param array $options  The options.
+ *
+ * @since 3.4.28
  */
 function epl_property_status( $statues = array(), $options = array() ) {
 
@@ -3578,5 +3587,4 @@ function epl_property_status( $statues = array(), $options = array() ) {
 	$options = array_merge( $default_options, (array) $options );
 	epl_stickers( $options, $stickers );
 }
-
-add_action( 'epl_property_status', 'epl_property_status' );
+add_action( 'epl_property_status', 'epl_property_status', 10, 2 );

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -3330,7 +3330,7 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 
 	$stickers = array(
 
-		'under_offer'      => array(
+		'under_offer'           => array(
 			'conditions' => array(
 				'property_status'      => 'current',
 				'property_under_offer' => array( 'yes' ),
@@ -3341,7 +3341,7 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 			'after'      => '',
 			'class'      => 'under-offer',
 		),
-		'home_open'        => array(
+		'home_open'             => array(
 			'conditions' => array(
 				'property_inspection_times' => array( null, '' ),
 			),
@@ -3353,7 +3353,7 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 			'class'      => 'open',
 		),
 
-		'new'              => array(
+		'new'                   => array(
 			'type'   => epl_get_core_post_types(),
 			'label'  => epl_get_option( 'label_new' ),
 			'before' => '',
@@ -3361,7 +3361,7 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 			'class'  => 'new',
 
 		),
-		'rental_lease'     => array(
+		'rental_lease'          => array(
 			'conditions' => array(
 				'property_status' => 'current',
 			),
@@ -3371,7 +3371,7 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 			'after'      => '',
 			'class'      => 'for-lease',
 		),
-		'leased'           => array(
+		'leased'                => array(
 			'conditions' => array(
 				'property_status' => 'leased',
 			),
@@ -3381,7 +3381,7 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 			'after'      => '',
 			'class'      => 'leased',
 		),
-		'current_sales'    => array(
+		'current_sales'         => array(
 			'conditions' => array(
 				'property_status' => 'current',
 			),
@@ -3391,7 +3391,7 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 			'after'      => '',
 			'class'      => 'for-sale',
 		),
-		'sold'             => array(
+		'sold'                  => array(
 			'conditions' => array(
 				'property_status' => 'sold',
 			),
@@ -3401,7 +3401,7 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 			'after'      => '',
 			'class'      => 'sold',
 		),
-		'commercial_sale_lease'  => array(
+		'commercial_sale_lease' => array(
 			'conditions' => array(
 				'property_status'           => 'current',
 				'property_com_listing_type' => array( 'both' ),
@@ -3412,7 +3412,7 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 			'after'      => '',
 			'class'      => 'for-sale',
 		),
-		'commercial_sale'  => array(
+		'commercial_sale'       => array(
 			'conditions' => array(
 				'property_status'           => 'current',
 				'property_com_listing_type' => array( 'sale' ),
@@ -3423,7 +3423,7 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 			'after'      => '',
 			'class'      => 'for-sale',
 		),
-		'commercial_lease' => array(
+		'commercial_lease'      => array(
 			'conditions' => array(
 				'property_status'           => 'current',
 				'property_com_listing_type' => array( 'lease' ),
@@ -3450,8 +3450,9 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 
 		$add_sticker = false;
 
-		if( !empty( $sticker_keys ) && !in_array( $key, $sticker_keys ) )
+		if ( ! empty( $sticker_keys ) && ! in_array( $key, $sticker_keys ) ) {
 			continue;
+		}
 
 		if ( ! empty( $sticker ) && is_array( $sticker ) ) {
 
@@ -3493,7 +3494,7 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 
 			}
 
-			if( $add_sticker ) {
+			if ( $add_sticker ) {
 				$return[ $key ] = array(
 					'label'  => $sticker['label'],
 					'class'  => $sticker['class'],
@@ -3514,20 +3515,20 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 /**
  * Check if sticker condition is valid.
  *
- * @param      <type>  $condition  The condition
- * @since 		3.4.28
+ * @param      <type> $condition  The condition
+ * @since       3.4.28
  */
 function epl_sticker_is_condition_valid( $condition, $compare = '=' ) {
 
-	$condition_met 		= 0;
-	$total_condition 	= count($condition);
-	$match				= false;
+	$condition_met   = 0;
+	$total_condition = count( $condition );
+	$match           = false;
 
-	foreach ($condition as $key => $value ) {
-		
-		if( is_array( $value ) ) {
+	foreach ( $condition as $key => $value ) {
 
-			if( in_array( get_property_meta( $key ), $value, true ) ) {
+		if ( is_array( $value ) ) {
+
+			if ( in_array( get_property_meta( $key ), $value, true ) ) {
 				$condition_met++;
 			}
 		} else {
@@ -3538,16 +3539,16 @@ function epl_sticker_is_condition_valid( $condition, $compare = '=' ) {
 	}
 	$match = $total_condition === $condition_met ? true : false;
 
-	return '=' === $compare ? $match : !$match;
+	return '=' === $compare ? $match : ! $match;
 }
 
 /**
  * Property Status Labels.
  *
- * @param      array  $statues  The statues
- * @param      array  $options  The options
- * @since      3.4.28 
- */	
+ * @param      array $statues  The statues
+ * @param      array $options  The options
+ * @since      3.4.28
+ */
 function epl_property_status( $statues = array(), $options = array() ) {
 
 	$statues_defaults = array(
@@ -3557,7 +3558,7 @@ function epl_property_status( $statues = array(), $options = array() ) {
 		'leased',
 		'sold',
 		'current_sales',
-		'commercial_sale_lease'
+		'commercial_sale_lease',
 	);
 
 	$statues = array_merge( $statues_defaults, (array) $statues );
@@ -3567,14 +3568,14 @@ function epl_property_status( $statues = array(), $options = array() ) {
 	$stickers = epl_get_stickers_array( $statues );
 
 	$default_options = array(
-		'wrap'			=>	true,
-		'wrap_class'	=>	'epl-listing-status',
+		'wrap'          => true,
+		'wrap_class'    => 'epl-listing-status',
 		'wrapper_tag'   => 'div',
 		'sticker_tag'   => 'span',
-		'sticker_class'	=>	'epl-widget-status-label',
+		'sticker_class' => 'epl-widget-status-label',
 	);
 
-	$options = array_merge( $default_options, ( array ) $options );
+	$options = array_merge( $default_options, (array) $options );
 	epl_stickers( $options, $stickers );
 }
 

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -3326,8 +3326,9 @@ function epl_stickers( $options = array(), $stickers = array() ) {
  *
  * @return mixed|void
  *
- * @since 3.4.28 Added array and filter.
+ * @throws Exception
  * @since 3.4.27
+ * @since 3.4.28 Added array and filter.
  */
 function epl_get_stickers_array( $sticker_keys = array() ) {
 
@@ -3455,7 +3456,7 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 
 		$add_sticker = false;
 
-		if ( ! empty( $sticker_keys ) && ! in_array( $key, $sticker_keys ) ) {
+		if ( ! empty( $sticker_keys ) && ! in_array( $key, $sticker_keys, true ) ) {
 			continue;
 		}
 
@@ -3553,9 +3554,10 @@ function epl_sticker_is_condition_valid( $condition, $compare = '=' ) {
 /**
  * Property Status Labels.
  *
- * @param array $statues  The statues.
- * @param array $options  The options.
+ * @param array $statues The statues.
+ * @param array $options The options.
  *
+ * @throws Exception
  * @since 3.4.28
  */
 function epl_property_status( $statues = array(), $options = array() ) {

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -3257,9 +3257,10 @@ function epl_get_post_id_from_unique_id( $unique_id = '' ) {
 /**
  * Renders stickers, based on meta values, an alternative to epl_price_stickers.
  *
- * @param array $options  The options.
+ * @param array $options The options.
  * @param array $stickers The stickers.
  *
+ * @throws Exception
  * @since 3.4.27
  */
 function epl_stickers( $options = array(), $stickers = array() ) {
@@ -3521,7 +3522,7 @@ function epl_get_stickers_array( $sticker_keys = array() ) {
 /**
  * Check if sticker condition is valid.
  *
- * @param string $condition The condition.
+ * @param array  $condition The condition.
  * @param string $compare   Comparison.
  *
  * @return bool

--- a/lib/post-types/post-types.php
+++ b/lib/post-types/post-types.php
@@ -264,8 +264,8 @@ function epl_manage_listing_column_listing_callback() {
 
 	$property_address_suburb = get_the_term_list( $post->ID, 'location', '', ', ', '' );
 	$heading                 = $property->get_property_meta( 'property_heading' );
-	$home_open                = $property->get_property_meta( 'property_inspection_times' );
-	$home_open                = trim( $home_open );
+	$home_open               = $property->get_property_meta( 'property_inspection_times' );
+	$home_open               = trim( $home_open );
 	$beds                    = $property->get_property_meta( 'property_bedrooms' );
 	$baths                   = $property->get_property_meta( 'property_bathrooms' );
 	$rooms                   = $property->get_property_meta( 'property_rooms', false );
@@ -367,7 +367,7 @@ function epl_manage_listing_column_listing_callback() {
 
 		$decimal_formatted = apply_filters( 'epl_land_value_decimal_format', false );
 
-		if( $decimal_formatted ) {
+		if ( $decimal_formatted ) {
 			$land = epl_format_amount( $land, true, true );
 		}
 		echo '<div class="epl_meta_land_details">';

--- a/lib/shortcodes/shortcode-listing-tax-feature.php
+++ b/lib/shortcodes/shortcode-listing-tax-feature.php
@@ -26,8 +26,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param array $atts Shortcode attributes.
  *
  * @return false|string|void
- * @since       1.1.2
- * @since 		3.4.27 fixed the issue : no spaces between classes when both class & template attributs are set.
+ * @since 1.1.2
+ * @since 3.4.27 Fixed the issue: no spaces between classes when both class & template attributs are set.
  */
 function epl_shortcode_listing_tax_feature_callback( $atts ) {
 	$property_types = epl_get_active_post_types();
@@ -62,7 +62,7 @@ function epl_shortcode_listing_tax_feature_callback( $atts ) {
 	$feature      = $attributes['feature'];
 	$feature_id   = $attributes['feature_id'];
 	$offset       = $attributes['offset'];
-	//$agent        = $attributes['agent'];
+	//$agent      = $attributes['agent'];
 	$template     = $attributes['template'];
 	$location     = $attributes['location'];
 	$tools_top    = $attributes['tools_top'];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "easy-property-listings",
   "title": "Easy Property Listings",
-  "version": "3.4.27",
+  "version": "3.4.28",
   "homepage": "https://easypropertylistings.com.au/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* New: Option added to number formatting function to trim decimal numbers. 
* New: Admin filter epl_land_value_decimal_format for land value decimal formatting.
* New: Globally loading shortcodes and widgets in order to allow page builders to use widgets. Additionally this will now render shortcodes when using front-end page builders.
* New: Helper action epl_property_status used to output the listing status in templates.
* Tweak: Enhancements to the new stickers function.
* Tweak. Altered land formatting in admin to remove decimals from land values unless they have decimal places.