### PR TITLE
3.4.30 svg in body tag

### DIFF
--- a/apigen.neon
+++ b/apigen.neon
@@ -21,7 +21,7 @@ charset: [UTF-8]
 main: EPL
 
 # title of generated documentation
-title: Easy Property Listings 3.4.30 Code Reference
+title: Easy Property Listings 3.4.31 Code Reference
 
 # base url used for sitemap (useful for public doc)
 baseUrl: http://docs.easypropertylistings.com.au/

--- a/easy-property-listings.php
+++ b/easy-property-listings.php
@@ -5,7 +5,7 @@
  * Description:  Fast. Flexible. Forward-thinking solution for real estate agents using WordPress. Easy Property Listing is one of the most dynamic and feature rich Real Estate plugin for WordPress available on the market today. Built for scale, contact generation and works with any theme!
  * Author: Merv Barrett
  * Author URI: http://www.realestateconnected.com.au/
- * Version: 3.4.30
+ * Version: 3.4.31
  * Text Domain: easy-property-listings
  * Domain Path: languages
  *
@@ -25,7 +25,7 @@
  * @package EPL
  * @category Core
  * @author Merv Barrett
- * @version 3.4.30
+ * @version 3.4.31
  */
 
 // Exit if accessed directly.
@@ -96,7 +96,7 @@ if ( ! class_exists( 'Easy_Property_Listings' ) ) :
 		public function setup_constants() {
 			// Plugin version.
 			if ( ! defined( 'EPL_PROPERTY_VER' ) ) {
-				define( 'EPL_PROPERTY_VER', '3.4.30' );
+				define( 'EPL_PROPERTY_VER', '3.4.31' );
 			}
 			// Plugin DB version.
 			if ( ! defined( 'EPL_PROPERTY_DB_VER' ) ) {

--- a/languages/easy-property-listings.pot
+++ b/languages/easy-property-listings.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the Easy Property Listings package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Easy Property Listings 3.4.30\n"
+"Project-Id-Version: Easy Property Listings 3.4.31\n"
 "Report-Msgid-Bugs-To: "
 "http://wordpress.org/support/plugin/easy-property-listings\n"
-"POT-Creation-Date: 2020-09-04 08:32:23+00:00\n"
+"POT-Creation-Date: 2020-09-17 02:52:32+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/lib/assets/assets-svg.php
+++ b/lib/assets/assets-svg.php
@@ -116,7 +116,16 @@ function epl_load_svg_listing_icons_head() {
 	}
 
 }
-add_action( 'wp_head', 'epl_load_svg_listing_icons_head', 90 );
+/**
+ * Load SVG using wp_body_open introduced in wp 5.2
+ *
+ * @since 3.4.31
+ */
+if ( function_exists( 'wp_body_open' ) ) {
+	add_action( 'wp_body_open', 'epl_load_svg_listing_icons_head', 10 );
+} else {
+	add_action( 'wp_head', 'epl_load_svg_listing_icons_head', 900 );
+}
 
 /**
  * SVG Social Media Icons Loaded in Head.
@@ -272,7 +281,17 @@ function epl_load_svg_social_icons_head() {
 		echo wp_kses( $social_icons, $allowed_tags );
 	}
 }
-add_action( 'wp_head', 'epl_load_svg_social_icons_head', 90 );
+
+/**
+ * Load Social SVG using wp_body_open introduced in wp 5.2
+ *
+ * @since 3.4.31
+ */
+if ( function_exists( 'wp_body_open' ) ) {
+	add_action( 'wp_body_open', 'epl_load_svg_social_icons_head', 10 );
+} else {
+	add_action( 'wp_head', 'epl_load_svg_social_icons_head', 900 );
+}
 
 /**
  * Whitelist display attribute for wp_kses_post

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "easy-property-listings",
   "title": "Easy Property Listings",
-  "version": "3.4.30",
+  "version": "3.4.31",
   "homepage": "https://easypropertylistings.com.au/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Fix: SVG Icons preventing favicon from loading in some themes. SVG's are now loading in body tag using wp_body_open hook introduced in WordPress 5.2.