### PR TITLE
fixed the output escaping for terms

### DIFF
--- a/lib/includes/class-epl-cpt.php
+++ b/lib/includes/class-epl-cpt.php
@@ -695,6 +695,7 @@ class EPL_CPT {
 	 *
 	 * @param string  $column The name of the column.
 	 * @param integer $post_id The post ID.
+	 * @since 3.4.33 Fixed the output escaping.
 	 */
 	public function populate_admin_columns( $column, $post_id ) {
 
@@ -738,7 +739,7 @@ class EPL_CPT {
 					}
 
 					// Join the terms, separating them with a comma.
-					echo join( ', ', wp_kses_post( $output ) );
+					echo join( ', ', array_map( 'wp_kses_post', $output ) );
 
 					// If no terms found.
 				} else {


### PR DESCRIPTION
* Fix: When using the custom post type library we fixed the output escaping.