### PR TITLE
3.4.35 master

### DIFF
--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -1383,7 +1383,7 @@ class EPL_Property_Meta {
 	 * Get Carport
 	 *
 	 * @since 2.0
-	 * @since 3.4.6 Fixed the incorrect meta key
+	 * @since 3.4.5 Fixed the incorrect meta key
 	 * @param string $returntype Options i = span, v = raw value, t = text, d = string, l = list item.
 	 * @return string
 	 */

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -2015,6 +2015,7 @@ class EPL_Property_Meta {
 	 * @since 2.0
 	 * @param string $metakey Meta key name.
 	 * @return mixed Value wrapped in a list item
+	 * @since 3.4.35 Tweak: Support for true/false values in features checklist.
 	 */
 	public function get_additional_features_html( $metakey ) {
 
@@ -2037,6 +2038,7 @@ class EPL_Property_Meta {
 				case 'Y':
 				case 'y':
 				case 'on':
+				case 'true':
 					$return = '<li class="' . $this->get_class_from_metakey( $metakey ) . '">' . apply_filters( 'epl_get_' . $metakey . '_label', $this->get_label_from_metakey( $metakey ) ) . '</li>';
 					break;
 
@@ -2046,6 +2048,7 @@ class EPL_Property_Meta {
 				case 'N':
 				case 'n':
 				case 'off':
+				case 'false':
 					$return = '';
 					break;
 

--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -1383,6 +1383,7 @@ class EPL_Property_Meta {
 	 * Get Carport
 	 *
 	 * @since 2.0
+	 * @since 3.4.6 Fixed the incorrect meta key
 	 * @param string $returntype Options i = span, v = raw value, t = text, d = string, l = list item.
 	 * @return string
 	 */
@@ -1396,7 +1397,7 @@ class EPL_Property_Meta {
 
 		$returntype = apply_filters( 'epl_get_property_carport_return_type', $returntype );
 		$label      = apply_filters( 'epl_get_property_carport_label', __( 'carport', 'easy-property-listings' ) );
-		$value      = $this->get_property_meta( 'property_garage' );
+		$value      = $this->get_property_meta( 'property_carport' );
 		$return     = '';
 
 		switch ( $returntype ) {

--- a/lib/includes/class-epl-render-fields.php
+++ b/lib/includes/class-epl-render-fields.php
@@ -532,6 +532,7 @@ class EPL_Render_Fields {
 	 *
 	 * @param array  $field The field.
 	 * @param string $val   The value.
+	 * @since 		 3.4.34 Added hidden empty field for checkboxes so that they always show up in $_POST data while saving.
 	 */
 	public function checkbox_single( $field, $val ) {
 
@@ -547,7 +548,9 @@ class EPL_Render_Fields {
 				if ( 1 === count( $field['opts'] ) ) {
 					$v = $field['label'];
 				}
-				echo '<span class="epl-field-row"><input type="checkbox" name="' . esc_attr( $field['name'] ) . '" class="' . esc_attr( $field['class'] ) . '" ' . wp_kses_post( $field['data'] ) . ' id="' . esc_attr( $field['id'] ) . '_' . esc_attr( $k ) . '" value="' . esc_attr( $k ) . '" ' . esc_attr( $checked ) . ' /> <label for="' . esc_html( $field['id'] ) . '_' . esc_attr( $k ) . '">' . esc_html( $v ) . '</label></span>';
+				echo '<span class="epl-field-row">
+				<input type="hidden" name="' . esc_attr( $field['name'] ) . '" value="" />
+				<input type="checkbox" name="' . esc_attr( $field['name'] ) . '" class="' . esc_attr( $field['class'] ) . '" ' . wp_kses_post( $field['data'] ) . ' id="' . esc_attr( $field['id'] ) . '_' . esc_attr( $k ) . '" value="' . esc_attr( $k ) . '" ' . esc_attr( $checked ) . ' /> <label for="' . esc_html( $field['id'] ) . '_' . esc_attr( $k ) . '">' . esc_html( $v ) . '</label></span>';
 			}
 		}
 	}
@@ -557,6 +560,7 @@ class EPL_Render_Fields {
 	 *
 	 * @param array  $field The field.
 	 * @param string $val   The value.
+	 * @since 		 3.4.34 Added hidden empty field for checkboxes so that they always show up in $_POST data while saving.
 	 */
 	public function checkbox_option( $field, $val ) {
 
@@ -568,7 +572,9 @@ class EPL_Render_Fields {
 						$checked = 'checked';
 					}
 				}
-				echo '<span class="epl-field-row"><input type="checkbox" name="' . esc_attr( $field['name'] ) . '" ' . wp_kses_post( $field['data'] ) . ' id="' . esc_attr( $field['id'] ) . '_' . esc_attr( $k ) . '" class="' . esc_attr( $field['class'] ) . '" value="' . esc_attr( $k ) . '" ' . esc_attr( $checked ) . ' /> <label for="' . esc_html( $field['id'] ) . '_' . esc_attr( $k ) . '">' . esc_html( $v ) . '</label></span>';
+				echo '<span class="epl-field-row">
+				<input type="hidden" name="' . esc_attr( $field['name'] ) . '" value="" />
+				<input type="checkbox" name="' . esc_attr( $field['name'] ) . '" ' . wp_kses_post( $field['data'] ) . ' id="' . esc_attr( $field['id'] ) . '_' . esc_attr( $k ) . '" class="' . esc_attr( $field['class'] ) . '" value="' . esc_attr( $k ) . '" ' . esc_attr( $checked ) . ' /> <label for="' . esc_html( $field['id'] ) . '_' . esc_attr( $k ) . '">' . esc_html( $v ) . '</label></span>';
 			}
 		}
 	}

--- a/lib/includes/class-epl-render-fields.php
+++ b/lib/includes/class-epl-render-fields.php
@@ -688,10 +688,11 @@ class EPL_Render_Fields {
 	 *
 	 * @param array  $field The field.
 	 * @param string $val   The value.
+	 * @since 3.4.35 fixed hidden field rendering.
 	 */
 	public function render_default( $field, $val ) {
 
-		if ( ! in_array( $field['type'], array( 'button', 'number', 'color', 'submit' ), true ) ) {
+		if ( ! in_array( $field['type'], array( 'button', 'number', 'color', 'submit', 'hidden' ), true ) ) {
 			$field['type'] = 'text';
 		}
 		echo $this->get_opening_field_tag( 'input', $field, true ); //phpcs:ignore

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -2490,6 +2490,7 @@ add_action( 'wp_ajax_nopriv_epl_update_default_view', 'epl_update_default_view' 
  * Custom the_content filter
  *
  * @since      2.2
+ * @since 	   3.4.35 Added support for WP blocks rendering	
  */
 function epl_the_content_filters() {
 
@@ -2505,6 +2506,7 @@ function epl_the_content_filters() {
 		add_filter( 'epl_get_the_content', array( &$vidembed, 'run_shortcode' ), 8 );
 		add_filter( 'epl_get_the_content', array( &$vidembed, 'autoembed' ), 8 );
 		add_filter( 'epl_get_the_content', 'do_shortcode', 11 );
+		add_filter( 'epl_get_the_content', 'do_blocks', 11 );
 	}
 
 	add_filter( 'epl_get_the_excerpt', 'epl_trim_excerpt' );

--- a/lib/shortcodes/class-epl-advanced-shortcode-listing.php
+++ b/lib/shortcodes/class-epl-advanced-shortcode-listing.php
@@ -539,6 +539,7 @@ class EPL_Advanced_Shortcode_Listing {
 	 * Set orderby clause
 	 *
 	 * @since 3.3
+	 * @since 3.4.35 Fixed the issue : [listing_advanced] not marked as EPL shortcode in WP_Query object
 	 */
 	public function set_orderby_clause() {
 

--- a/lib/shortcodes/class-epl-advanced-shortcode-listing.php
+++ b/lib/shortcodes/class-epl-advanced-shortcode-listing.php
@@ -560,13 +560,12 @@ class EPL_Advanced_Shortcode_Listing {
 			unset( $this->args['order'] );
 		}
 
-		$args['instance_id'] = $this->attributes['instance_id'];
+		$this->args['instance_id'] = $this->attributes['instance_id'];
 
 		// add sortby arguments to query, if listings sorted by $_GET['sortby'];.
-		$args = epl_add_orderby_args( $args, 'shortcode', 'listing_advanced' );
-
+		$this->args = epl_add_orderby_args( $this->args, 'shortcode', 'listing_advanced' );
 		// Option to filter args.
-		$args = apply_filters( 'epl_shortcode_listing_advanced_args', $this->args, $this->attributes );
+		$this->args = apply_filters( 'epl_shortcode_listing_advanced_args', $this->args, $this->attributes );
 	}
 
 	/**


### PR DESCRIPTION
* Tweak: Added support for WordPress 5.6 blocks rendering.
* Tweak: Support for true/false values in features checklist.
* Fix : [listing_advanced] not marked as EPL shortcode in WP_Query object.
* Fix: Incorrect meta key in carport function.
* Fix: Hidden field rendering.