### PR TITLE
Automatic conversion of false to array is deprecated fix

### DIFF
--- a/lib/includes/functions.php
+++ b/lib/includes/functions.php
@@ -2196,7 +2196,7 @@ function epl_parse_atts( $atts ) {
 			$query['meta_query'][ $key . '_clause' ] = $this_query;
 		}
 	}
-	return isset( $query['meta_query'] ) ? $query['meta_query'] : false;
+	return isset( $query['meta_query'] ) ? $query['meta_query'] : array();
 }
 
 /**


### PR DESCRIPTION
https://wiki.php.net/rfc/autovivification_false

"Every single usage autovivification on false will throw a deprecation error in PHP 8.1 and throw a fatal error in PHP 9.0."