### PR TITLE
Enhancements

### DIFF
--- a/lib/includes/class-epl-property-meta.php
+++ b/lib/includes/class-epl-property-meta.php
@@ -240,6 +240,7 @@ class EPL_Property_Meta {
 	 * @since 2.0
 	 * @since 3.4.27 Added filter for href, handling of non date inspection values.
 	 * @since 3.4.44 Added filter for deciding whether to remove inspection entry.
+         * @since 3.5.3  Fix : Deprecation warning - Make sure inspection time is not null before passing through trim.
 	 */
 	public function get_property_inspection_times( $ical = true, $meta_key = 'property_inspection_times' ) {
 		if ( 'leased' === $this->get_property_meta( 'property_status' ) || 'sold' === $this->get_property_meta( 'property_status' ) ) {
@@ -247,7 +248,7 @@ class EPL_Property_Meta {
 		}
 
 		$inspection_time = $this->get_property_meta( $meta_key );
-		$inspection_time = trim( $inspection_time );
+		$inspection_time = !is_null( $inspection_time ) ? trim( $inspection_time ) : '';
 
 		$not_date = array();
 

--- a/lib/includes/template-functions.php
+++ b/lib/includes/template-functions.php
@@ -323,12 +323,14 @@ function epl_get_fallback_content_path() {
  * @since 3.0
  * @since 3.4.38 New: Additional parameter default_template to pass the default template which will be used if the template is not found.
  * @since 3.4.41 Fix: Only the default template was loading.
+ * @since 3.5.3  Hook to filter find array as well as final template.       
  */
 function epl_get_template_part( $template, $arguments = array(), $default_template = false ) {
 
 	$base_path         = epl_get_content_path();
 	$default           = $default_template ? $default_template : $template;
 	$find[]            = epl_template_path() . $template;
+        $find              = apply_filters( 'epl_template_part_find', $find, $template, $arguments, $default_template );     
 	$template_location = locate_template( array_unique( $find ) );
 
 	if ( ! $template_location ) {
@@ -350,7 +352,7 @@ function epl_get_template_part( $template, $arguments = array(), $default_templa
 		${$key} = $val;
 	}
 
-	include $template;
+	include apply_filters( 'epl_get_template_part', $template, $arguments, $default_template );
 }
 
 /**

--- a/lib/shortcodes/shortcode-listing-search.php
+++ b/lib/shortcodes/shortcode-listing-search.php
@@ -24,6 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since       1.2
  * @since       3.4.45 Tweak: Pass user provided attributes to the [listing_search] Shortcode template.
  * @since       3.5 Support for instance ID, fallback generates unique instance ID automatically, added support for 'status' in shortcodes.
+ * @since       3.5.3 Filter to disable default template & action to add custom template.
  */
 function epl_shortcode_listing_search_callback( $atts ) {
 
@@ -40,8 +41,12 @@ function epl_shortcode_listing_search_callback( $atts ) {
                 $attributes['property_status'] = $atts['status'];
         }
 	ob_start();
-	// Rendering view of listing search shortcode.
-	epl_get_template_part( 'shortcodes/listing-search/' . ( ! empty( $attributes['view'] ) ? trim( $attributes['view'] ) . '.php' : 'default.php' ), array( 'atts' => $attributes, 'user_atts' => $atts ) );
+        if( apply_filters( 'epl_search_should_load_default_template', true, $attributes, $atts ) ) {
+                // Rendering view of listing search shortcode.
+                epl_get_template_part( 'shortcodes/listing-search/' . ( ! empty( $attributes['view'] ) ? trim( $attributes['view'] ) . '.php' : 'default.php' ), array( 'atts' => $attributes, 'user_atts' => $atts ) );
+        } else {
+                do_action( 'epl_search_load_template', $attributes, $atts );
+        }
 	return ob_get_clean();
 }
 add_shortcode( 'listing_search', 'epl_shortcode_listing_search_callback' );


### PR DESCRIPTION
@since 3.5.3 Fix : Deprecation warning - Make sure inspection time is not null before passing through trim.
@since 3.5.3 Hook to filter find array as well as final template.
@since 3.5.3 Filter to disable default template & action to add custom template.