### PR TITLE
REST and unset fixes

### DIFF
--- a/lib/includes/class-epl-rest-api.php
+++ b/lib/includes/class-epl-rest-api.php
@@ -7,6 +7,7 @@
  * @copyright   Copyright (c) 2024, Merv Barrett
  * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since       3.5.8
+ * @since 3.5.10 Fix error when group fields are empty.
  */
 
 // Exit if accessed directly.
@@ -90,8 +91,13 @@ if ( ! class_exists( 'EPL_Rest_API' ) ) :
 
 						foreach ( $epl_meta_box['groups'] as $group ) {
 
-							$fields = $group['fields'];
-							$fields = array_filter( $fields );
+                                                        if ( isset( $group['fields'] ) && is_array( $group['fields'] ) ) {
+                                                                $fields = $group['fields'];
+                                                                $fields = array_filter( $fields );
+
+                                                        } else {
+                                                                $fields = [];
+                                                        }
 
 							if ( ! empty( $fields ) ) {
 

--- a/lib/meta-boxes/meta-box-init.php
+++ b/lib/meta-boxes/meta-box-init.php
@@ -20,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0
  * @since 3.4.1 Added property_price_currency,property_rent_currency,property_floorplan_mod_date.
  * @since 3.4.23 Ordered the additional featured items to a-z order.
+ * @since 3.5.10 Fix warning when group is unset using filter.
  */
 function epl_get_meta_boxes() {
 
@@ -1581,7 +1582,7 @@ function epl_get_meta_boxes() {
 
 	if ( ! empty( $epl_meta_boxes ) ) {
 
-		foreach ( $epl_meta_boxes as &$epl_meta_box ) {
+		foreach ( $epl_meta_boxes as $box_index => &$epl_meta_box ) {
 			$meta_box_block_id = str_replace( '-', '_', $epl_meta_box['id'] );
 			$epl_meta_box      = apply_filters( 'epl_meta_box_block_' . $meta_box_block_id, $epl_meta_box );
 			if ( ! empty( $epl_meta_box['groups'] ) ) {
@@ -1595,7 +1596,10 @@ function epl_get_meta_boxes() {
 						}
 					}
 				}
-			}
+			} else {
+
+                                unset( $epl_meta_boxes[ $box_index ] );
+                        }
 		}
 	}
 

--- a/lib/post-types/post-types.php
+++ b/lib/post-types/post-types.php
@@ -263,6 +263,7 @@ add_action( 'epl_manage_listing_column_property_thumb', 'epl_manage_listing_colu
  * @since 3.4.27 Fixed html escaping issue and formatting for land size.
  * @since 3.4.30 Using epl_get_meta_field_label for dynamic labels.
  * @since 3.5 Escaping values.
+ * @since 3.5.10 Fix warning for trim when home_open is null.
  */
 function epl_manage_listing_column_listing_callback() {
 	global $post,$property;
@@ -270,7 +271,7 @@ function epl_manage_listing_column_listing_callback() {
 	$property_address_suburb = get_the_term_list( $post->ID, 'location', '', ', ', '' );
 	$heading                 = $property->get_property_meta( 'property_heading' );
 	$home_open               = $property->get_property_meta( 'property_inspection_times' );
-	$home_open               = trim( $home_open );
+	$home_open               = is_string( $home_open ) ? trim( $home_open ) : '';
 	$beds                    = $property->get_property_meta( 'property_bedrooms' );
 	$baths                   = $property->get_property_meta( 'property_bathrooms' );
 	$rooms                   = $property->get_property_meta( 'property_rooms', false );


### PR DESCRIPTION
@since 3.5.10 Fix error when group fields are empty.
@since 3.5.10 Fix warning when group is unset using filter.
@since 3.5.10 Fix warning for trim when home_open is null.